### PR TITLE
Clear structs in rmdRescue()

### DIFF
--- a/recordmydesktop/src/rmd_rescue.c
+++ b/recordmydesktop/src/rmd_rescue.c
@@ -49,9 +49,9 @@ int rmdRescue(const char *path){
     unsigned short  width,
                     height;
 
-    ProgData pdata;
-    EncData enc_data;
-    CacheData cache_data;
+    ProgData pdata={0};
+    EncData enc_data={0};
+    CacheData cache_data={0};
 
     rmdSetupDefaultArgs(&pdata.args);
 


### PR DESCRIPTION
Credit goes to Justin Frankel for finding this issue when using
--rescue; see discussion in
https://github.com/Enselic/recordmydesktop/pull/3