### PR TITLE
fix misspellings in codebase

### DIFF
--- a/gtk-recordmydesktop/INSTALL
+++ b/gtk-recordmydesktop/INSTALL
@@ -8,7 +8,7 @@ DEPENDENCIES:
 
 GNU automake >=1.5
 Python >= 2.4
-PyGTK>=2.10 or PyGTK>=2.8 with gnome-python-extras >= 2.11.3  (Be carefull since this is checked on runtime. )
+PyGTK>=2.10 or PyGTK>=2.8 with gnome-python-extras >= 2.11.3  (Be careful since this is checked on runtime. )
 recordMyDesktop 0.3.5
 
 To compile the program you have to go through the regular drill:

--- a/gtk-recordmydesktop/po/ar.po
+++ b/gtk-recordmydesktop/po/ar.po
@@ -94,11 +94,11 @@ msgid "Improper window specification."
 msgstr "تحديد النافذة خاطئ."
 
 #: src/rmdStrings.py:31
-msgid "Cannot attach shared memory to proccess."
+msgid "Cannot attach shared memory to process."
 msgstr "لا يمكن ربط ذاكرة متشاركة بالمعالجة."
 
 #: src/rmdStrings.py:32
-msgid "Cannot open file for writting."
+msgid "Cannot open file for writing."
 msgstr "لا يمكن فتح الملف للكتابة."
 
 #: src/rmdStrings.py:33
@@ -136,7 +136,7 @@ msgstr "الوصف"
 #: src/rmdStrings.py:42
 msgid ""
 "Recording is finished.\n"
-"recordMyDesktop has exited with uknown\n"
+"recordMyDesktop has exited with unknown\n"
 "error code"
 msgstr ""
 "تم الانتهاء من التصوير.\n"
@@ -191,7 +191,7 @@ msgstr "اضغط للخروج من البرنامج."
 #: src/rmdStrings.py:52
 msgid ""
 "Select the video quality of your recording.\n"
-"(Lower quality will require more proccessing power,\n"
+"(Lower quality will require more processing power,\n"
 "so it's recommended, when encoding on the fly,\n"
 "to leave at 100)"
 msgstr ""
@@ -241,7 +241,7 @@ msgid ""
 "Please wait while your recording is being encoded\n"
 "WARNING!!!\n"
 "If you press Cancel or close this window,\n"
-"this proccess cannot be resumed!"
+"this process cannot be resumed!"
 msgstr ""
 "الرجاء الانتظار بينما يتم إنتاج تصويرك\n"
 "تحذير!!!\n"
@@ -253,7 +253,7 @@ msgid "complete"
 msgstr "انتهى"
 
 #: src/rmdStrings.py:68
-msgid "Overwite Existing Files"
+msgid "Overwrite Existing Files"
 msgstr "الكتابة فوق الملفات الموجودة"
 
 #: src/rmdStrings.py:68

--- a/gtk-recordmydesktop/po/bg.po
+++ b/gtk-recordmydesktop/po/bg.po
@@ -97,11 +97,11 @@ msgid "Improper window specification."
 msgstr "Неправилна спецификация на прозореца."
 
 #: src/rmdStrings.py:31
-msgid "Cannot attach shared memory to proccess."
+msgid "Cannot attach shared memory to process."
 msgstr ""
 
 #: src/rmdStrings.py:32
-msgid "Cannot open file for writting."
+msgid "Cannot open file for writing."
 msgstr "Файлът не може да бъде отворен за запис"
 
 #: src/rmdStrings.py:33
@@ -139,7 +139,7 @@ msgstr "Описание"
 #: src/rmdStrings.py:42
 msgid ""
 "Recording is finished.\n"
-"recordMyDesktop has exited with uknown\n"
+"recordMyDesktop has exited with unknown\n"
 "error code"
 msgstr ""
 "Записът завърши.\n"
@@ -197,7 +197,7 @@ msgstr "Цъкнете за да излезете от програмата."
 #: src/rmdStrings.py:52
 msgid ""
 "Select the video quality of your recording.\n"
-"(Lower quality will require more proccessing power,\n"
+"(Lower quality will require more processing power,\n"
 "so it's recommended, when encoding on the fly,\n"
 "to leave at 100)"
 msgstr ""
@@ -247,7 +247,7 @@ msgid ""
 "Please wait while your recording is being encoded\n"
 "WARNING!!!\n"
 "If you press Cancel or close this window,\n"
-"this proccess cannot be resumed!"
+"this process cannot be resumed!"
 msgstr ""
 "Моля изчакайте, докато вашия запис се кодира\n"
 "ВНИМАНИЕ!!!\n"
@@ -259,7 +259,7 @@ msgid "complete"
 msgstr "завършено"
 
 #: src/rmdStrings.py:68
-msgid "Overwite Existing Files"
+msgid "Overwrite Existing Files"
 msgstr "Презаписване на съществуващи файлове"
 
 #: src/rmdStrings.py:68

--- a/gtk-recordmydesktop/po/ca.po
+++ b/gtk-recordmydesktop/po/ca.po
@@ -100,11 +100,11 @@ msgid "Improper window specification."
 msgstr "Especificació de finestra impròpia."
 
 #: src/rmdStrings.py:31
-msgid "Cannot attach shared memory to proccess."
+msgid "Cannot attach shared memory to process."
 msgstr " ﻿No es pot adjuntar memòria compartida al procés."
 
 #: src/rmdStrings.py:32
-msgid "Cannot open file for writting."
+msgid "Cannot open file for writing."
 msgstr "No es pot obrir el fitxer per escriure-hi."
 
 #: src/rmdStrings.py:33
@@ -143,7 +143,7 @@ msgstr "Descripció"
 #: src/rmdStrings.py:42
 msgid ""
 "Recording is finished.\n"
-"recordMyDesktop has exited with uknown\n"
+"recordMyDesktop has exited with unknown\n"
 "error code"
 msgstr ""
 "La gravació ha acabat.\n"
@@ -199,7 +199,7 @@ msgstr "Feu clic per sortir del programa."
 #: src/rmdStrings.py:52
 msgid ""
 "Select the video quality of your recording.\n"
-"(Lower quality will require more proccessing power,\n"
+"(Lower quality will require more processing power,\n"
 "so it's recommended, when encoding on the fly,\n"
 "to leave at 100)"
 msgstr ""
@@ -251,7 +251,7 @@ msgid ""
 "Please wait while your recording is being encoded\n"
 "WARNING!!!\n"
 "If you press Cancel or close this window,\n"
-"this proccess cannot be resumed!"
+"this process cannot be resumed!"
 msgstr ""
 "Si us plau espereu mentre es codifica la vostra gravació\n"
 "¡¡¡AVIS!!!\n"
@@ -263,7 +263,7 @@ msgid "complete"
 msgstr "complet"
 
 #: src/rmdStrings.py:68
-msgid "Overwite Existing Files"
+msgid "Overwrite Existing Files"
 msgstr "Sobrescriu els fitxers existents"
 
 #: src/rmdStrings.py:68

--- a/gtk-recordmydesktop/po/de.po
+++ b/gtk-recordmydesktop/po/de.po
@@ -105,11 +105,11 @@ msgid "Improper window specification."
 msgstr "Ungeeignete Fenstereinstellung."
 
 #: src/rmdStrings.py:31
-msgid "Cannot attach shared memory to proccess."
+msgid "Cannot attach shared memory to process."
 msgstr "Shared-memory-Erweiterung konnte nicht gestartet werden."
 
 #: src/rmdStrings.py:32
-msgid "Cannot open file for writting."
+msgid "Cannot open file for writing."
 msgstr "Konnte Datei zum Schreiben nicht öffnen."
 
 #: src/rmdStrings.py:33
@@ -148,7 +148,7 @@ msgstr "Beschreibung"
 #: src/rmdStrings.py:42
 msgid ""
 "Recording is finished.\n"
-"recordMyDesktop has exited with uknown\n"
+"recordMyDesktop has exited with unknown\n"
 "error code"
 msgstr ""
 "Aufnahme wurde beendet.\n"
@@ -206,7 +206,7 @@ msgstr "Hier klicken, um das Programm zu beenden."
 #: src/rmdStrings.py:52
 msgid ""
 "Select the video quality of your recording.\n"
-"(Lower quality will require more proccessing power,\n"
+"(Lower quality will require more processing power,\n"
 "so it's recommended, when encoding on the fly,\n"
 "to leave at 100)"
 msgstr ""
@@ -256,7 +256,7 @@ msgid ""
 "Please wait while your recording is being encoded\n"
 "WARNING!!!\n"
 "If you press Cancel or close this window,\n"
-"this proccess cannot be resumed!"
+"this process cannot be resumed!"
 msgstr ""
 "Bitte warten, während Ihre Aufnahme encodiert wird.\n"
 "Achtung!\n"
@@ -268,7 +268,7 @@ msgid "complete"
 msgstr "vollständig"
 
 #: src/rmdStrings.py:68
-msgid "Overwite Existing Files"
+msgid "Overwrite Existing Files"
 msgstr "Vorhandene Dateien überschreiben"
 
 #: src/rmdStrings.py:68

--- a/gtk-recordmydesktop/po/el.po
+++ b/gtk-recordmydesktop/po/el.po
@@ -99,11 +99,11 @@ msgid "Improper window specification."
 msgstr "Ακατάλληλη επιλογή παραθύρου."
 
 #: src/rmdStrings.py:31
-msgid "Cannot attach shared memory to proccess."
+msgid "Cannot attach shared memory to process."
 msgstr "Αδυναμία προσκόλλησης κοινής μνήμης στη διεργασία."
 
 #: src/rmdStrings.py:32
-msgid "Cannot open file for writting."
+msgid "Cannot open file for writing."
 msgstr "Αδυναμία ανοίγματος του αρχείου για εγγραφή."
 
 #: src/rmdStrings.py:33
@@ -144,7 +144,7 @@ msgstr "Περιγραφή "
 #: src/rmdStrings.py:42
 msgid ""
 "Recording is finished.\n"
-"recordMyDesktop has exited with uknown\n"
+"recordMyDesktop has exited with unknown\n"
 "error code"
 msgstr ""
 "Η εγγραφή τελείωσε.\n"
@@ -196,7 +196,7 @@ msgstr "Κάνετε κλικ για να τερματίσετε την εφαρ
 #: src/rmdStrings.py:52
 msgid ""
 "Select the video quality of your recording.\n"
-"(Lower quality will require more proccessing power,\n"
+"(Lower quality will require more processing power,\n"
 "so it's recommended, when encoding on the fly,\n"
 "to leave at 100)"
 msgstr ""
@@ -246,7 +246,7 @@ msgid ""
 "Please wait while your recording is being encoded\n"
 "WARNING!!!\n"
 "If you press Cancel or close this window,\n"
-"this proccess cannot be resumed!"
+"this process cannot be resumed!"
 msgstr ""
 "Παρακαλώ περιμένετε να τελειώσει η κωδικοποίηση. \n"
 "ΠΡΟΣΟΧΗ!!! \n"
@@ -258,7 +258,7 @@ msgid "complete"
 msgstr "ολοκληρώθηκε"
 
 #: src/rmdStrings.py:68
-msgid "Overwite Existing Files"
+msgid "Overwrite Existing Files"
 msgstr "Διαγραφή υπαρχόντων αρχείων."
 
 #: src/rmdStrings.py:68

--- a/gtk-recordmydesktop/po/es.po
+++ b/gtk-recordmydesktop/po/es.po
@@ -100,11 +100,11 @@ msgid "Improper window specification."
 msgstr "Especificación de ventanas impropia."
 
 #: src/rmdStrings.py:31
-msgid "Cannot attach shared memory to proccess."
+msgid "Cannot attach shared memory to process."
 msgstr "No se pudo adjuntar memoria compartida al proceso."
 
 #: src/rmdStrings.py:32
-msgid "Cannot open file for writting."
+msgid "Cannot open file for writing."
 msgstr "No se pudo abrir el archivo para escritura."
 
 #: src/rmdStrings.py:33
@@ -142,7 +142,7 @@ msgstr "Descripción"
 #: src/rmdStrings.py:42
 msgid ""
 "Recording is finished.\n"
-"recordMyDesktop has exited with uknown\n"
+"recordMyDesktop has exited with unknown\n"
 "error code"
 msgstr ""
 "La grabación ha terminado.\n"
@@ -198,7 +198,7 @@ msgstr "Haz clic para salir del programa."
 #: src/rmdStrings.py:52
 msgid ""
 "Select the video quality of your recording.\n"
-"(Lower quality will require more proccessing power,\n"
+"(Lower quality will require more processing power,\n"
 "so it's recommended, when encoding on the fly,\n"
 "to leave at 100)"
 msgstr ""
@@ -251,7 +251,7 @@ msgid ""
 "Please wait while your recording is being encoded\n"
 "WARNING!!!\n"
 "If you press Cancel or close this window,\n"
-"this proccess cannot be resumed!"
+"this process cannot be resumed!"
 msgstr ""
 "Por favor, espere mientras se codifica la grabación\n"
 "¡¡AVISO!!\n"
@@ -263,7 +263,7 @@ msgid "complete"
 msgstr "completo"
 
 #: src/rmdStrings.py:68
-msgid "Overwite Existing Files"
+msgid "Overwrite Existing Files"
 msgstr "Sobreescribir archivos existentes"
 
 #: src/rmdStrings.py:68

--- a/gtk-recordmydesktop/po/fr.po
+++ b/gtk-recordmydesktop/po/fr.po
@@ -103,11 +103,11 @@ msgid "Improper window specification."
 msgstr "Spécifications de la fenêtre incorrectes."
 
 #: src/rmdStrings.py:31
-msgid "Cannot attach shared memory to proccess."
+msgid "Cannot attach shared memory to process."
 msgstr "Impossible d'allouer de la mémoire partagée au processus."
 
 #: src/rmdStrings.py:32
-msgid "Cannot open file for writting."
+msgid "Cannot open file for writing."
 msgstr "Impossible d'ouvrir le fichier en écriture."
 
 #: src/rmdStrings.py:33
@@ -147,7 +147,7 @@ msgstr "Description"
 #: src/rmdStrings.py:42
 msgid ""
 "Recording is finished.\n"
-"recordMyDesktop has exited with uknown\n"
+"recordMyDesktop has exited with unknown\n"
 "error code"
 msgstr ""
 "L'enregistrement est fini.\n"
@@ -202,7 +202,7 @@ msgstr "Cliquer pour quitter le programme."
 #: src/rmdStrings.py:52
 msgid ""
 "Select the video quality of your recording.\n"
-"(Lower quality will require more proccessing power,\n"
+"(Lower quality will require more processing power,\n"
 "so it's recommended, when encoding on the fly,\n"
 "to leave at 100)"
 msgstr ""
@@ -252,7 +252,7 @@ msgid ""
 "Please wait while your recording is being encoded\n"
 "WARNING!!!\n"
 "If you press Cancel or close this window,\n"
-"this proccess cannot be resumed!"
+"this process cannot be resumed!"
 msgstr ""
 "Veuillez patientez durant l'encodage de votre enregistrement\n"
 "ATTENTION !!!\n"
@@ -264,7 +264,7 @@ msgid "complete"
 msgstr "terminé"
 
 #: src/rmdStrings.py:68
-msgid "Overwite Existing Files"
+msgid "Overwrite Existing Files"
 msgstr "Écraser les fichiers existants"
 
 #: src/rmdStrings.py:68

--- a/gtk-recordmydesktop/po/he_IL.pot
+++ b/gtk-recordmydesktop/po/he_IL.pot
@@ -95,11 +95,11 @@ msgid "Improper window specification."
 msgstr "מפרט חלון לא תקין."
 
 #: src/rmdStrings.py:31
-msgid "Cannot attach shared memory to proccess."
+msgid "Cannot attach shared memory to process."
 msgstr "לא מצליח לחבר זיכרון משותף לתהליך."
 
 #: src/rmdStrings.py:32
-msgid "Cannot open file for writting."
+msgid "Cannot open file for writing."
 msgstr "לא מצליח לפתוח את הקובץ במצב כתיבה."
 
 #: src/rmdStrings.py:33
@@ -137,7 +137,7 @@ msgstr "תיאור"
 #: src/rmdStrings.py:42
 msgid ""
 "Recording is finished.\n"
-"recordMyDesktop has exited with uknown\n"
+"recordMyDesktop has exited with unknown\n"
 "error code"
 msgstr ""
 "ההקלטה הסתיימה.\n"
@@ -193,7 +193,7 @@ msgstr "לחץ כדי לצאת מהתוכנה"
 #: src/rmdStrings.py:52
 msgid ""
 "Select the video quality of your recording.\n"
-"(Lower quality will require more proccessing power,\n"
+"(Lower quality will require more processing power,\n"
 "so it's recommended, when encoding on the fly,\n"
 "to leave at 100)"
 msgstr ""
@@ -242,7 +242,7 @@ msgid ""
 "Please wait while your recording is being encoded\n"
 "WARNING!!!\n"
 "If you press Cancel or close this window,\n"
-"this proccess cannot be resumed!"
+"this process cannot be resumed!"
 msgstr ""
 "אנא המתן בזמן שהקלטתך מקודד\n"
 "אזהרה!!!\n"
@@ -254,7 +254,7 @@ msgid "complete"
 msgstr "הושלם"
 
 #: src/rmdStrings.py:68
-msgid "Overwite Existing Files"
+msgid "Overwrite Existing Files"
 msgstr "דרוס קבצים קיימים"
 
 #: src/rmdStrings.py:68

--- a/gtk-recordmydesktop/po/it.po
+++ b/gtk-recordmydesktop/po/it.po
@@ -100,11 +100,11 @@ msgid "Improper window specification."
 msgstr "Descrizione impropria della finestra."
 
 #: src/rmdStrings.py:31
-msgid "Cannot attach shared memory to proccess."
+msgid "Cannot attach shared memory to process."
 msgstr "Impossibile assegnare la memoria condivisa ai processi."
 
 #: src/rmdStrings.py:32
-msgid "Cannot open file for writting."
+msgid "Cannot open file for writing."
 msgstr "Impossibile aprire il file per la scrittura."
 
 #: src/rmdStrings.py:33
@@ -142,7 +142,7 @@ msgstr "Descrizione"
 #: src/rmdStrings.py:42
 msgid ""
 "Recording is finished.\n"
-"recordMyDesktop has exited with uknown\n"
+"recordMyDesktop has exited with unknown\n"
 "error code"
 msgstr ""
 "La registrazione è terminata.\n"
@@ -198,7 +198,7 @@ msgstr "Premere qui, per uscire dal programma."
 #: src/rmdStrings.py:52
 msgid ""
 "Select the video quality of your recording.\n"
-"(Lower quality will require more proccessing power,\n"
+"(Lower quality will require more processing power,\n"
 "so it's recommended, when encoding on the fly,\n"
 "to leave at 100)"
 msgstr ""
@@ -249,7 +249,7 @@ msgid ""
 "Please wait while your recording is being encoded\n"
 "WARNING!!!\n"
 "If you press Cancel or close this window,\n"
-"this proccess cannot be resumed!"
+"this process cannot be resumed!"
 msgstr ""
 "Attendere fin quando la registrazione sarà terminata\n"
 "ATTENZIONE!!!\n"
@@ -261,7 +261,7 @@ msgid "complete"
 msgstr "completo"
 
 #: src/rmdStrings.py:68
-msgid "Overwite Existing Files"
+msgid "Overwrite Existing Files"
 msgstr "Sovrascrive i file esistenti"
 
 #: src/rmdStrings.py:68

--- a/gtk-recordmydesktop/po/ja.po
+++ b/gtk-recordmydesktop/po/ja.po
@@ -92,11 +92,11 @@ msgid "Improper window specification."
 msgstr "不適切ウインドー選択"
 
 #: src/rmdStrings.py:31
-msgid "Cannot attach shared memory to proccess."
+msgid "Cannot attach shared memory to process."
 msgstr "プルセスにシェアードメモリ繋がれなかった"
 
 #: src/rmdStrings.py:32
-msgid "Cannot open file for writting."
+msgid "Cannot open file for writing."
 msgstr "ファイル書き込みする為に開けなかった"
 
 #: src/rmdStrings.py:33
@@ -134,7 +134,7 @@ msgstr "詳細"
 #: src/rmdStrings.py:42
 msgid ""
 "Recording is finished.\n"
-"recordMyDesktop has exited with uknown\n"
+"recordMyDesktop has exited with unknown\n"
 "error code"
 msgstr ""
 "登録完了\n"
@@ -185,7 +185,7 @@ msgstr "クリックして終了"
 #: src/rmdStrings.py:52
 msgid ""
 "Select the video quality of your recording.\n"
-"(Lower quality will require more proccessing power,\n"
+"(Lower quality will require more processing power,\n"
 "so it's recommended, when encoding on the fly,\n"
 "to leave at 100)"
 msgstr ""
@@ -234,7 +234,7 @@ msgid ""
 "Please wait while your recording is being encoded\n"
 "WARNING!!!\n"
 "If you press Cancel or close this window,\n"
-"this proccess cannot be resumed!"
+"this process cannot be resumed!"
 msgstr ""
 "エンコードしている間、お待ちください。\n"
 "ご注意！\n"
@@ -245,7 +245,7 @@ msgid "complete"
 msgstr "完了"
 
 #: src/rmdStrings.py:68
-msgid "Overwite Existing Files"
+msgid "Overwrite Existing Files"
 msgstr "ファイルを上書きする"
 
 #: src/rmdStrings.py:68

--- a/gtk-recordmydesktop/po/messages.pot
+++ b/gtk-recordmydesktop/po/messages.pot
@@ -92,11 +92,11 @@ msgid "Improper window specification."
 msgstr ""
 
 #: src/rmdStrings.py:31
-msgid "Cannot attach shared memory to proccess."
+msgid "Cannot attach shared memory to process."
 msgstr ""
 
 #: src/rmdStrings.py:32
-msgid "Cannot open file for writting."
+msgid "Cannot open file for writing."
 msgstr ""
 
 #: src/rmdStrings.py:33
@@ -132,7 +132,7 @@ msgstr ""
 #: src/rmdStrings.py:42
 msgid ""
 "Recording is finished.\n"
-"recordMyDesktop has exited with uknown\n"
+"recordMyDesktop has exited with unknown\n"
 "error code"
 msgstr ""
 
@@ -178,7 +178,7 @@ msgstr ""
 #: src/rmdStrings.py:52
 msgid ""
 "Select the video quality of your recording.\n"
-"(Lower quality will require more proccessing power,\n"
+"(Lower quality will require more processing power,\n"
 "so it's recommended, when encoding on the fly,\n"
 "to leave at 100)"
 msgstr ""
@@ -220,7 +220,7 @@ msgid ""
 "Please wait while your recording is being encoded\n"
 "WARNING!!!\n"
 "If you press Cancel or close this window,\n"
-"this proccess cannot be resumed!"
+"this process cannot be resumed!"
 msgstr ""
 
 #: src/rmdStrings.py:65
@@ -228,7 +228,7 @@ msgid "complete"
 msgstr ""
 
 #: src/rmdStrings.py:68
-msgid "Overwite Existing Files"
+msgid "Overwrite Existing Files"
 msgstr ""
 
 #: src/rmdStrings.py:68

--- a/gtk-recordmydesktop/po/nl.po
+++ b/gtk-recordmydesktop/po/nl.po
@@ -95,11 +95,11 @@ msgid "Improper window specification."
 msgstr "Verkeerde vensterspecificatie"
 
 #: src/rmdStrings.py:31
-msgid "Cannot attach shared memory to proccess."
+msgid "Cannot attach shared memory to process."
 msgstr "Kan gedeeld geheugen niet verbinden aan proces"
 
 #: src/rmdStrings.py:32
-msgid "Cannot open file for writting."
+msgid "Cannot open file for writing."
 msgstr "Kan bestand niet openen voor schrijven"
 
 #: src/rmdStrings.py:33
@@ -137,7 +137,7 @@ msgstr "Beschrijving"
 #: src/rmdStrings.py:42
 msgid ""
 "Recording is finished.\n"
-"recordMyDesktop has exited with uknown\n"
+"recordMyDesktop has exited with unknown\n"
 "error code"
 msgstr ""
 "Opname is beeindigd. "
@@ -193,7 +193,7 @@ msgstr "Klik om het programma te beeindigen"
 #: src/rmdStrings.py:52
 msgid ""
 "Select the video quality of your recording.\n"
-"(Lower quality will require more proccessing power,\n"
+"(Lower quality will require more processing power,\n"
 "so it's recommended, when encoding on the fly,\n"
 "to leave at 100)"
 msgstr ""
@@ -243,7 +243,7 @@ msgid ""
 "Please wait while your recording is being encoded\n"
 "WARNING!!!\n"
 "If you press Cancel or close this window,\n"
-"this proccess cannot be resumed!"
+"this process cannot be resumed!"
 msgstr ""
 "Wacht aub terwijl de opname word gecodeerd\n"
 "WAARSCHUWING!!!\n"
@@ -255,7 +255,7 @@ msgid "complete"
 msgstr "Compleet"
 
 #: src/rmdStrings.py:68
-msgid "Overwite Existing Files"
+msgid "Overwrite Existing Files"
 msgstr "Overschrijf bestaande bestanden"
 
 #: src/rmdStrings.py:68

--- a/gtk-recordmydesktop/po/pl.po
+++ b/gtk-recordmydesktop/po/pl.po
@@ -98,11 +98,11 @@ msgid "Improper window specification."
 msgstr "Niepoprawne określenie okna."
 
 #: src/rmdStrings.py:31
-msgid "Cannot attach shared memory to proccess."
+msgid "Cannot attach shared memory to process."
 msgstr "Nie można dołączyć pamięci dzielonej do procesu."
 
 #: src/rmdStrings.py:32
-msgid "Cannot open file for writting."
+msgid "Cannot open file for writing."
 msgstr "Nie można otworzyć pliku do zapisu."
 
 #: src/rmdStrings.py:33
@@ -140,7 +140,7 @@ msgstr "Opis"
 #: src/rmdStrings.py:42
 msgid ""
 "Recording is finished.\n"
-"recordMyDesktop has exited with uknown\n"
+"recordMyDesktop has exited with unknown\n"
 "error code"
 msgstr ""
 "Nagrywanie zakończone.\n"
@@ -196,7 +196,7 @@ msgstr "Kliknij aby zakończyć program."
 #: src/rmdStrings.py:52
 msgid ""
 "Select the video quality of your recording.\n"
-"(Lower quality will require more proccessing power,\n"
+"(Lower quality will require more processing power,\n"
 "so it's recommended, when encoding on the fly,\n"
 "to leave at 100)"
 msgstr ""
@@ -246,7 +246,7 @@ msgid ""
 "Please wait while your recording is being encoded\n"
 "WARNING!!!\n"
 "If you press Cancel or close this window,\n"
-"this proccess cannot be resumed!"
+"this process cannot be resumed!"
 msgstr ""
 "Proszę czekać. Trwa kodowanie nagrania\n"
 "UWAGA!!!\n"
@@ -258,7 +258,7 @@ msgid "complete"
 msgstr "ukończone"
 
 #: src/rmdStrings.py:68
-msgid "Overwite Existing Files"
+msgid "Overwrite Existing Files"
 msgstr "Nadpisuj istniejące pliki"
 
 #: src/rmdStrings.py:68

--- a/gtk-recordmydesktop/po/pt.po
+++ b/gtk-recordmydesktop/po/pt.po
@@ -90,11 +90,11 @@ msgid "Improper window specification."
 msgstr "Janela improriada especificada"
 
 #: src/rmdStrings.py:31
-msgid "Cannot attach shared memory to proccess."
+msgid "Cannot attach shared memory to process."
 msgstr "Impossivel anexar memória partilhada ao processo"
 
 #: src/rmdStrings.py:32
-msgid "Cannot open file for writting."
+msgid "Cannot open file for writing."
 msgstr "Impossivel abrir o ficheiro para escrever"
 
 #: src/rmdStrings.py:33
@@ -132,7 +132,7 @@ msgstr "Descrição"
 #: src/rmdStrings.py:42
 msgid ""
 "Recording is finished.\n"
-"recordMyDesktop has exited with uknown\n"
+"recordMyDesktop has exited with unknown\n"
 "error code"
 msgstr ""
 "Gravação terminada.\n"
@@ -188,7 +188,7 @@ msgstr "Clique aqui para sair do programa"
 #: src/rmdStrings.py:52
 msgid ""
 "Select the video quality of your recording.\n"
-"(Lower quality will require more proccessing power,\n"
+"(Lower quality will require more processing power,\n"
 "so it's recommended, when encoding on the fly,\n"
 "to leave at 100)"
 msgstr ""
@@ -239,7 +239,7 @@ msgid ""
 "Please wait while your recording is being encoded\n"
 "WARNING!!!\n"
 "If you press Cancel or close this window,\n"
-"this proccess cannot be resumed!"
+"this process cannot be resumed!"
 msgstr ""
 "Por favor espere enquanto a sua gravação é codificada\n"
 "AVISO!!\n"
@@ -251,7 +251,7 @@ msgid "complete"
 msgstr "completo"
 
 #: src/rmdStrings.py:68
-msgid "Overwite Existing Files"
+msgid "Overwrite Existing Files"
 msgstr "Sobrepor Ficheiros Existentes"
 
 #: src/rmdStrings.py:68

--- a/gtk-recordmydesktop/po/pt_BR.po
+++ b/gtk-recordmydesktop/po/pt_BR.po
@@ -92,11 +92,11 @@ msgid "Improper window specification."
 msgstr "Janela imprópria especificada."
 
 #: src/rmdStrings.py:31
-msgid "Cannot attach shared memory to proccess."
+msgid "Cannot attach shared memory to process."
 msgstr "Impossível anexar memória partilhada ao processo"
 
 #: src/rmdStrings.py:32
-msgid "Cannot open file for writting."
+msgid "Cannot open file for writing."
 msgstr "Impossível abrir o arquivo para escrever"
 
 #: src/rmdStrings.py:33
@@ -135,7 +135,7 @@ msgstr "Descrição"
 #: src/rmdStrings.py:42
 msgid ""
 "Recording is finished.\n"
-"recordMyDesktop has exited with uknown\n"
+"recordMyDesktop has exited with unknown\n"
 "error code"
 msgstr ""
 "Gravação terminada.\n"
@@ -191,7 +191,7 @@ msgstr "Clique aqui para sair do programa."
 #: src/rmdStrings.py:52
 msgid ""
 "Select the video quality of your recording.\n"
-"(Lower quality will require more proccessing power,\n"
+"(Lower quality will require more processing power,\n"
 "so it's recommended, when encoding on the fly,\n"
 "to leave at 100)"
 msgstr ""
@@ -242,7 +242,7 @@ msgid ""
 "Please wait while your recording is being encoded\n"
 "WARNING!!!\n"
 "If you press Cancel or close this window,\n"
-"this proccess cannot be resumed!"
+"this process cannot be resumed!"
 msgstr ""
 "Por favor espere enquanto a sua gravação é codificada\n"
 "AVISO!!\n"
@@ -254,7 +254,7 @@ msgid "complete"
 msgstr "completo"
 
 #: src/rmdStrings.py:68
-msgid "Overwite Existing Files"
+msgid "Overwrite Existing Files"
 msgstr "Sobreescrever Arquivos Existentes"
 
 #: src/rmdStrings.py:68

--- a/gtk-recordmydesktop/po/ru.po
+++ b/gtk-recordmydesktop/po/ru.po
@@ -95,11 +95,11 @@ msgid "Improper window specification."
 msgstr "Неправильные параметры окна"
 
 #: src/rmdStrings.py:31
-msgid "Cannot attach shared memory to proccess."
+msgid "Cannot attach shared memory to process."
 msgstr "Невозможно подключить shared memory к процессу"
 
 #: src/rmdStrings.py:32
-msgid "Cannot open file for writting."
+msgid "Cannot open file for writing."
 msgstr "Невозможно открыть файл на запись"
 
 #: src/rmdStrings.py:33
@@ -138,7 +138,7 @@ msgstr "Описание"
 #: src/rmdStrings.py:42
 msgid ""
 "Recording is finished.\n"
-"recordMyDesktop has exited with uknown\n"
+"recordMyDesktop has exited with unknown\n"
 "error code"
 msgstr ""
 "Запись окончена.\n"
@@ -194,7 +194,7 @@ msgstr "Нажмите для выхода из программы"
 #: src/rmdStrings.py:52
 msgid ""
 "Select the video quality of your recording.\n"
-"(Lower quality will require more proccessing power,\n"
+"(Lower quality will require more processing power,\n"
 "so it's recommended, when encoding on the fly,\n"
 "to leave at 100)"
 msgstr ""
@@ -244,7 +244,7 @@ msgid ""
 "Please wait while your recording is being encoded\n"
 "WARNING!!!\n"
 "If you press Cancel or close this window,\n"
-"this proccess cannot be resumed!"
+"this process cannot be resumed!"
 msgstr ""
 "Пожалуйста, подождите пока ваша запись кодируется\n"
 "ВНИМАНИЕ!!!\n"
@@ -256,7 +256,7 @@ msgid "complete"
 msgstr "готово"
 
 #: src/rmdStrings.py:68
-msgid "Overwite Existing Files"
+msgid "Overwrite Existing Files"
 msgstr "Переписать существующие файлы"
 
 #: src/rmdStrings.py:68

--- a/gtk-recordmydesktop/po/sv.po
+++ b/gtk-recordmydesktop/po/sv.po
@@ -95,11 +95,11 @@ msgid "Improper window specification."
 msgstr "Felaktig fönsterspecifikation."
 
 #: ../src/rmdStrings.py:31
-msgid "Cannot attach shared memory to proccess."
+msgid "Cannot attach shared memory to process."
 msgstr "Kan inte fästa delat minne till process."
 
 #: ../src/rmdStrings.py:32
-msgid "Cannot open file for writting."
+msgid "Cannot open file for writing."
 msgstr "Kan inte öppna fil för skrivning."
 
 #: ../src/rmdStrings.py:33
@@ -137,7 +137,7 @@ msgstr "Beskrivning"
 #: ../src/rmdStrings.py:42
 msgid ""
 "Recording is finished.\n"
-"recordMyDesktop has exited with uknown\n"
+"recordMyDesktop has exited with unknown\n"
 "error code"
 msgstr ""
 "Inspelningen är färdig.\n"
@@ -195,7 +195,7 @@ msgstr "Klicka för att avsluta programmet."
 #: ../src/rmdStrings.py:52
 msgid ""
 "Select the video quality of your recording.\n"
-"(Lower quality will require more proccessing power,\n"
+"(Lower quality will require more processing power,\n"
 "so it's recommended, when encoding on the fly,\n"
 "to leave at 100)"
 msgstr ""
@@ -245,7 +245,7 @@ msgid ""
 "Please wait while your recording is being encoded\n"
 "WARNING!!!\n"
 "If you press Cancel or close this window,\n"
-"this proccess cannot be resumed!"
+"this process cannot be resumed!"
 msgstr ""
 "Vänta under tiden din inspelning kodas\n"
 "VARNING!!!\n"
@@ -257,7 +257,7 @@ msgid "complete"
 msgstr "färdig"
 
 #: ../src/rmdStrings.py:68
-msgid "Overwite Existing Files"
+msgid "Overwrite Existing Files"
 msgstr "Skriv över befintliga filer"
 
 #: ../src/rmdStrings.py:68

--- a/gtk-recordmydesktop/po/tr.po
+++ b/gtk-recordmydesktop/po/tr.po
@@ -98,11 +98,11 @@ msgid "Improper window specification."
 msgstr "Yanlış pencere seçimi."
 
 #: src/rmdStrings.py:31
-msgid "Cannot attach shared memory to proccess."
+msgid "Cannot attach shared memory to process."
 msgstr "Ortak bellek sürece eklenemedi."
 
 #: src/rmdStrings.py:32
-msgid "Cannot open file for writting."
+msgid "Cannot open file for writing."
 msgstr "Dosyayı yazmak için açamadı."
 
 #: src/rmdStrings.py:33
@@ -140,7 +140,7 @@ msgstr "Açıklama"
 #: src/rmdStrings.py:42
 msgid ""
 "Recording is finished.\n"
-"recordMyDesktop has exited with uknown\n"
+"recordMyDesktop has exited with unknown\n"
 "error code"
 msgstr ""
 "Kayıt işlemi tamamlandı.\n"
@@ -196,7 +196,7 @@ msgstr "Programdan çıkmak için tıklayın."
 #: src/rmdStrings.py:52
 msgid ""
 "Select the video quality of your recording.\n"
-"(Lower quality will require more proccessing power,\n"
+"(Lower quality will require more processing power,\n"
 "so it's recommended, when encoding on the fly,\n"
 "to leave at 100)"
 msgstr ""
@@ -246,7 +246,7 @@ msgid ""
 "Please wait while your recording is being encoded\n"
 "WARNING!!!\n"
 "If you press Cancel or close this window,\n"
-"this proccess cannot be resumed!"
+"this process cannot be resumed!"
 msgstr ""
 "Lütfen kayıt kodlanırken bekleyin\n"
 "UYARI!!!\n"
@@ -258,7 +258,7 @@ msgid "complete"
 msgstr "tamamlandı"
 
 #: src/rmdStrings.py:68
-msgid "Overwite Existing Files"
+msgid "Overwrite Existing Files"
 msgstr "Varolan Dosyaların Üstüne Yaz"
 
 #: src/rmdStrings.py:68

--- a/gtk-recordmydesktop/po/zh_CN.po
+++ b/gtk-recordmydesktop/po/zh_CN.po
@@ -95,11 +95,11 @@ msgid "Improper window specification."
 msgstr "窗口规格不合法。"
 
 #: src/rmdStrings.py:31
-msgid "Cannot attach shared memory to proccess."
+msgid "Cannot attach shared memory to process."
 msgstr "无法向进程附加共享内存。"
 
 #: src/rmdStrings.py:32
-msgid "Cannot open file for writting."
+msgid "Cannot open file for writing."
 msgstr "无法打开文件以写入。"
 
 #: src/rmdStrings.py:33
@@ -137,7 +137,7 @@ msgstr "描述"
 #: src/rmdStrings.py:42
 msgid ""
 "Recording is finished.\n"
-"recordMyDesktop has exited with uknown\n"
+"recordMyDesktop has exited with unknown\n"
 "error code"
 msgstr ""
 "记录结束。\n"
@@ -191,7 +191,7 @@ msgstr "点击以退出程序。"
 #: src/rmdStrings.py:52
 msgid ""
 "Select the video quality of your recording.\n"
-"(Lower quality will require more proccessing power,\n"
+"(Lower quality will require more processing power,\n"
 "so it's recommended, when encoding on the fly,\n"
 "to leave at 100)"
 msgstr ""
@@ -238,7 +238,7 @@ msgid ""
 "Please wait while your recording is being encoded\n"
 "WARNING!!!\n"
 "If you press Cancel or close this window,\n"
-"this proccess cannot be resumed!"
+"this process cannot be resumed!"
 msgstr ""
 "当记录进行时请稍等\n"
 "警告！！！\n"
@@ -249,7 +249,7 @@ msgid "complete"
 msgstr "完成"
 
 #: src/rmdStrings.py:68
-msgid "Overwite Existing Files"
+msgid "Overwrite Existing Files"
 msgstr "覆盖已存在文件"
 
 #: src/rmdStrings.py:68

--- a/gtk-recordmydesktop/src/gtk-recordMyDesktop.in
+++ b/gtk-recordmydesktop/src/gtk-recordMyDesktop.in
@@ -28,7 +28,7 @@
 
 import sys
 
-#this is the installation direcotry,
+#this is the installation directory,
 #which is determined during configuration
 #default /usr/local/lib/python<version>/site-packages
 PYTHONDIR='@PYTHONDIR@'

--- a/gtk-recordmydesktop/src/rmdSimple.py
+++ b/gtk-recordmydesktop/src/rmdSimple.py
@@ -329,7 +329,7 @@ class simpleWidget(object):
             #the header
             savefile.readline()
             savefile.readline()
-            #the options,each has a coment above
+            #the options,each has a comment above
             for i in range(2):
                 savefile.readline()
                 self.values.append(int(savefile.readline()))

--- a/gtk-recordmydesktop/src/rmdStrings.py
+++ b/gtk-recordmydesktop/src/rmdStrings.py
@@ -28,8 +28,8 @@ rmdErrStr={
         9*256:_('Cannot connect to Xserver.'),
         10*256:_('Color depth is not 24bpp.'),
         11*256:_('Improper window specification.'),
-        12*256:_('Cannot attach shared memory to proccess.'),
-        13*256:_('Cannot open file for writting.'),
+        12*256:_('Cannot attach shared memory to process.'),
+        13*256:_('Cannot open file for writing.'),
         14*256:_('Cannot load the Jack library (dlopen/dlsym error on libjack.so).'),
         15*256:_('Cannot create new client.'),
         16*256:_('Cannot activate client.'),
@@ -39,7 +39,7 @@ rmdErrStr={
 TrayIconStr={
         'RecFinishedKnown':_("Recording is finished.\nrecordMyDesktop has exited with status"),
         'ErrDesc':_("Description"),
-        'RecFinishedUnknown':_("Recording is finished.\nrecordMyDesktop has exited with uknown\nerror code")
+        'RecFinishedUnknown':_("Recording is finished.\nrecordMyDesktop has exited with unknown\nerror code")
    }
 
 
@@ -49,7 +49,7 @@ smplTooltipLabels=[_('Click here to select a window to record'),
                 _('Click to start the recording.\nThis window will hide itself.'),
                 _('Click to choose a filename and location.\nDefault is out.ogv in your home folder.\nIf the file already exists, the new one\nwill have a number attached on its name\n(this behavior can be changed )'),
                 _('Click to exit the program.'),
-                _('Select the video quality of your recording.\n(Lower quality will require more proccessing power,\nso it\'s recommended, when encoding on the fly,\nto leave at 100)'),
+                _('Select the video quality of your recording.\n(Lower quality will require more processing power,\nso it\'s recommended, when encoding on the fly,\nto leave at 100)'),
                 _('Enable/Disable sound recording.'),
                 _('Select the audio quality of your recording.'),
                 _('Click here to access more options.')]
@@ -61,11 +61,11 @@ smplStrings={   'Record':_("Record"),
     }
 
 monStrings={'Cancel':_("Cancel"),
-            'PleaseWait':_("Please wait while your recording is being encoded\nWARNING!!!\nIf you press Cancel or close this window,\nthis proccess cannot be resumed!"),
+            'PleaseWait':_("Please wait while your recording is being encoded\nWARNING!!!\nIf you press Cancel or close this window,\nthis process cannot be resumed!"),
             'complete':_("complete")
     }
 
-prefLabelStrings=[_('Overwite Existing Files'),_('Working Directory'),
+prefLabelStrings=[_('Overwrite Existing Files'),_('Working Directory'),
                 _('Frames Per Second'),_('Encode On the Fly'),_('Zero Compression'),
                 _('Quick Subsampling'),_('Full shots at every frame'),
                 _('Channels'),_('Frequency'),_('Device'),_('Display'),_('Mouse Cursor'),

--- a/qt-recordmydesktop/configure.ac
+++ b/qt-recordmydesktop/configure.ac
@@ -45,7 +45,7 @@ export PYTHONPATH=$PYTHONPATH
 
 export PYQT4_VERSION=`python -c 'import PyQt4; from PyQt4 import QtCore; print QtCore.PYQT_VERSION_STR'  2>>/dev/null `
 if test x$PYQT4_VERSION == x; then
-    AC_MSG_ERROR(You need PyQt4>=4.1 installed to procceed);
+    AC_MSG_ERROR(You need PyQt4>=4.1 installed to proceed);
 fi
 b=$(echo "$PYQT4_VERSION" | awk 'BEGIN{ FS="." } { print $1 "\n" $2 "\n" $3 }')
 c=($b)
@@ -59,7 +59,7 @@ if test $PYQT4_MAJOR != 4; then
 fi
 
 if test $PYQT4_MINOR -lt 1; then
-    AC_MSG_ERROR(You need PyQt4>=4.1 installed to procceed
+    AC_MSG_ERROR(You need PyQt4>=4.1 installed to proceed
     (earlier version found installed));
 fi
 

--- a/qt-recordmydesktop/po/ar.po
+++ b/qt-recordmydesktop/po/ar.po
@@ -94,11 +94,11 @@ msgid "Improper window specification."
 msgstr "تحديد النافذة خاطئ."
 
 #: src/rmdStrings.py:31
-msgid "Cannot attach shared memory to proccess."
+msgid "Cannot attach shared memory to process."
 msgstr "لا يمكن ربط ذاكرة متشاركة بالمعالجة."
 
 #: src/rmdStrings.py:32
-msgid "Cannot open file for writting."
+msgid "Cannot open file for writing."
 msgstr "لا يمكن فتح الملف للكتابة."
 
 #: src/rmdStrings.py:33
@@ -136,7 +136,7 @@ msgstr "الوصف"
 #: src/rmdStrings.py:42
 msgid ""
 "Recording is finished.\n"
-"recordMyDesktop has exited with uknown\n"
+"recordMyDesktop has exited with unknown\n"
 "error code"
 msgstr ""
 "تم الانتهاء من التصوير.\n"
@@ -191,7 +191,7 @@ msgstr "اضغط للخروج من البرنامج."
 #: src/rmdStrings.py:52
 msgid ""
 "Select the video quality of your recording.\n"
-"(Lower quality will require more proccessing power,\n"
+"(Lower quality will require more processing power,\n"
 "so it's recommended, when encoding on the fly,\n"
 "to leave at 100)"
 msgstr ""
@@ -241,7 +241,7 @@ msgid ""
 "Please wait while your recording is being encoded\n"
 "WARNING!!!\n"
 "If you press Cancel or close this window,\n"
-"this proccess cannot be resumed!"
+"this process cannot be resumed!"
 msgstr ""
 "الرجاء الانتظار بينما يتم إنتاج تصويرك\n"
 "تحذير!!!\n"
@@ -253,7 +253,7 @@ msgid "complete"
 msgstr "انتهى"
 
 #: src/rmdStrings.py:68
-msgid "Overwite Existing Files"
+msgid "Overwrite Existing Files"
 msgstr "الكتابة فوق الملفات الموجودة"
 
 #: src/rmdStrings.py:68

--- a/qt-recordmydesktop/po/ca.po
+++ b/qt-recordmydesktop/po/ca.po
@@ -100,11 +100,11 @@ msgid "Improper window specification."
 msgstr "Especificació de finestra impròpia."
 
 #: src/rmdStrings.py:31
-msgid "Cannot attach shared memory to proccess."
+msgid "Cannot attach shared memory to process."
 msgstr " ﻿No es pot adjuntar memòria compartida al procés."
 
 #: src/rmdStrings.py:32
-msgid "Cannot open file for writting."
+msgid "Cannot open file for writing."
 msgstr "No es pot obrir el fitxer per escriure-hi."
 
 #: src/rmdStrings.py:33
@@ -143,7 +143,7 @@ msgstr "Descripció"
 #: src/rmdStrings.py:42
 msgid ""
 "Recording is finished.\n"
-"recordMyDesktop has exited with uknown\n"
+"recordMyDesktop has exited with unknown\n"
 "error code"
 msgstr ""
 "La gravació ha acabat.\n"
@@ -199,7 +199,7 @@ msgstr "Feu clic per sortir del programa."
 #: src/rmdStrings.py:52
 msgid ""
 "Select the video quality of your recording.\n"
-"(Lower quality will require more proccessing power,\n"
+"(Lower quality will require more processing power,\n"
 "so it's recommended, when encoding on the fly,\n"
 "to leave at 100)"
 msgstr ""
@@ -251,7 +251,7 @@ msgid ""
 "Please wait while your recording is being encoded\n"
 "WARNING!!!\n"
 "If you press Cancel or close this window,\n"
-"this proccess cannot be resumed!"
+"this process cannot be resumed!"
 msgstr ""
 "Si us plau espereu mentre es codifica la vostra gravació\n"
 "¡¡¡AVIS!!!\n"
@@ -263,7 +263,7 @@ msgid "complete"
 msgstr "complet"
 
 #: src/rmdStrings.py:68
-msgid "Overwite Existing Files"
+msgid "Overwrite Existing Files"
 msgstr "Sobrescriu els fitxers existents"
 
 #: src/rmdStrings.py:68

--- a/qt-recordmydesktop/po/de.po
+++ b/qt-recordmydesktop/po/de.po
@@ -105,11 +105,11 @@ msgid "Improper window specification."
 msgstr "Ungeeignete Fenstereinstellung."
 
 #: src/rmdStrings.py:31
-msgid "Cannot attach shared memory to proccess."
+msgid "Cannot attach shared memory to process."
 msgstr "Shared-memory-Erweiterung konnte nicht gestartet werden."
 
 #: src/rmdStrings.py:32
-msgid "Cannot open file for writting."
+msgid "Cannot open file for writing."
 msgstr "Konnte Datei zum Schreiben nicht öffnen."
 
 #: src/rmdStrings.py:33
@@ -148,7 +148,7 @@ msgstr "Beschreibung"
 #: src/rmdStrings.py:42
 msgid ""
 "Recording is finished.\n"
-"recordMyDesktop has exited with uknown\n"
+"recordMyDesktop has exited with unknown\n"
 "error code"
 msgstr ""
 "Aufnahme wurde beendet.\n"
@@ -206,7 +206,7 @@ msgstr "Hier klicken, um das Programm zu beenden."
 #: src/rmdStrings.py:52
 msgid ""
 "Select the video quality of your recording.\n"
-"(Lower quality will require more proccessing power,\n"
+"(Lower quality will require more processing power,\n"
 "so it's recommended, when encoding on the fly,\n"
 "to leave at 100)"
 msgstr ""
@@ -256,7 +256,7 @@ msgid ""
 "Please wait while your recording is being encoded\n"
 "WARNING!!!\n"
 "If you press Cancel or close this window,\n"
-"this proccess cannot be resumed!"
+"this process cannot be resumed!"
 msgstr ""
 "Bitte warten, während Ihre Aufnahme encodiert wird.\n"
 "Achtung!\n"
@@ -268,7 +268,7 @@ msgid "complete"
 msgstr "vollständig"
 
 #: src/rmdStrings.py:68
-msgid "Overwite Existing Files"
+msgid "Overwrite Existing Files"
 msgstr "Vorhandene Dateien überschreiben"
 
 #: src/rmdStrings.py:68

--- a/qt-recordmydesktop/po/el.po
+++ b/qt-recordmydesktop/po/el.po
@@ -99,11 +99,11 @@ msgid "Improper window specification."
 msgstr "Ακατάλληλη επιλογή παραθύρου."
 
 #: src/rmdStrings.py:31
-msgid "Cannot attach shared memory to proccess."
+msgid "Cannot attach shared memory to process."
 msgstr "Αδυναμία προσκόλλησης κοινής μνήμης στη διεργασία."
 
 #: src/rmdStrings.py:32
-msgid "Cannot open file for writting."
+msgid "Cannot open file for writing."
 msgstr "Αδυναμία ανοίγματος του αρχείου για εγγραφή."
 
 #: src/rmdStrings.py:33
@@ -144,7 +144,7 @@ msgstr "Περιγραφή "
 #: src/rmdStrings.py:42
 msgid ""
 "Recording is finished.\n"
-"recordMyDesktop has exited with uknown\n"
+"recordMyDesktop has exited with unknown\n"
 "error code"
 msgstr ""
 "Η εγγραφή τελείωσε.\n"
@@ -196,7 +196,7 @@ msgstr "Κάνετε κλικ για να τερματίσετε την εφαρ
 #: src/rmdStrings.py:52
 msgid ""
 "Select the video quality of your recording.\n"
-"(Lower quality will require more proccessing power,\n"
+"(Lower quality will require more processing power,\n"
 "so it's recommended, when encoding on the fly,\n"
 "to leave at 100)"
 msgstr ""
@@ -246,7 +246,7 @@ msgid ""
 "Please wait while your recording is being encoded\n"
 "WARNING!!!\n"
 "If you press Cancel or close this window,\n"
-"this proccess cannot be resumed!"
+"this process cannot be resumed!"
 msgstr ""
 "Παρακαλώ περιμένετε να τελειώσει η κωδικοποίηση. \n"
 "ΠΡΟΣΟΧΗ!!! \n"
@@ -258,7 +258,7 @@ msgid "complete"
 msgstr "ολοκληρώθηκε"
 
 #: src/rmdStrings.py:68
-msgid "Overwite Existing Files"
+msgid "Overwrite Existing Files"
 msgstr "Διαγραφή υπαρχόντων αρχείων."
 
 #: src/rmdStrings.py:68

--- a/qt-recordmydesktop/po/es.po
+++ b/qt-recordmydesktop/po/es.po
@@ -100,11 +100,11 @@ msgid "Improper window specification."
 msgstr "Especificación de ventanas impropia."
 
 #: src/rmdStrings.py:31
-msgid "Cannot attach shared memory to proccess."
+msgid "Cannot attach shared memory to process."
 msgstr "No se pudo adjuntar memoria compartida al proceso."
 
 #: src/rmdStrings.py:32
-msgid "Cannot open file for writting."
+msgid "Cannot open file for writing."
 msgstr "No se pudo abrir el archivo para escritura."
 
 #: src/rmdStrings.py:33
@@ -142,7 +142,7 @@ msgstr "Descripción"
 #: src/rmdStrings.py:42
 msgid ""
 "Recording is finished.\n"
-"recordMyDesktop has exited with uknown\n"
+"recordMyDesktop has exited with unknown\n"
 "error code"
 msgstr ""
 "La grabación ha terminado.\n"
@@ -198,7 +198,7 @@ msgstr "Haz clic para salir del programa."
 #: src/rmdStrings.py:52
 msgid ""
 "Select the video quality of your recording.\n"
-"(Lower quality will require more proccessing power,\n"
+"(Lower quality will require more processing power,\n"
 "so it's recommended, when encoding on the fly,\n"
 "to leave at 100)"
 msgstr ""
@@ -251,7 +251,7 @@ msgid ""
 "Please wait while your recording is being encoded\n"
 "WARNING!!!\n"
 "If you press Cancel or close this window,\n"
-"this proccess cannot be resumed!"
+"this process cannot be resumed!"
 msgstr ""
 "Por favor, espere mientras se codifica la grabación\n"
 "¡¡AVISO!!\n"
@@ -263,7 +263,7 @@ msgid "complete"
 msgstr "completo"
 
 #: src/rmdStrings.py:68
-msgid "Overwite Existing Files"
+msgid "Overwrite Existing Files"
 msgstr "Sobreescribir archivos existentes"
 
 #: src/rmdStrings.py:68

--- a/qt-recordmydesktop/po/fr.po
+++ b/qt-recordmydesktop/po/fr.po
@@ -103,11 +103,11 @@ msgid "Improper window specification."
 msgstr "Spécifications de la fenêtre incorrectes."
 
 #: src/rmdStrings.py:31
-msgid "Cannot attach shared memory to proccess."
+msgid "Cannot attach shared memory to process."
 msgstr "Impossible d'allouer de la mémoire partagée au processus."
 
 #: src/rmdStrings.py:32
-msgid "Cannot open file for writting."
+msgid "Cannot open file for writing."
 msgstr "Impossible d'ouvrir le fichier en écriture."
 
 #: src/rmdStrings.py:33
@@ -147,7 +147,7 @@ msgstr "Description"
 #: src/rmdStrings.py:42
 msgid ""
 "Recording is finished.\n"
-"recordMyDesktop has exited with uknown\n"
+"recordMyDesktop has exited with unknown\n"
 "error code"
 msgstr ""
 "L'enregistrement est fini.\n"
@@ -202,7 +202,7 @@ msgstr "Cliquer pour quitter le programme."
 #: src/rmdStrings.py:52
 msgid ""
 "Select the video quality of your recording.\n"
-"(Lower quality will require more proccessing power,\n"
+"(Lower quality will require more processing power,\n"
 "so it's recommended, when encoding on the fly,\n"
 "to leave at 100)"
 msgstr ""
@@ -252,7 +252,7 @@ msgid ""
 "Please wait while your recording is being encoded\n"
 "WARNING!!!\n"
 "If you press Cancel or close this window,\n"
-"this proccess cannot be resumed!"
+"this process cannot be resumed!"
 msgstr ""
 "Veuillez patientez durant l'encodage de votre enregistrement\n"
 "ATTENTION !!!\n"
@@ -264,7 +264,7 @@ msgid "complete"
 msgstr "terminé"
 
 #: src/rmdStrings.py:68
-msgid "Overwite Existing Files"
+msgid "Overwrite Existing Files"
 msgstr "Écraser les fichiers existants"
 
 #: src/rmdStrings.py:68

--- a/qt-recordmydesktop/po/he_IL.pot
+++ b/qt-recordmydesktop/po/he_IL.pot
@@ -95,11 +95,11 @@ msgid "Improper window specification."
 msgstr "מפרט חלון לא תקין."
 
 #: src/rmdStrings.py:31
-msgid "Cannot attach shared memory to proccess."
+msgid "Cannot attach shared memory to process."
 msgstr "לא מצליח לחבר זיכרון משותף לתהליך."
 
 #: src/rmdStrings.py:32
-msgid "Cannot open file for writting."
+msgid "Cannot open file for writing."
 msgstr "לא מצליח לפתוח את הקובץ במצב כתיבה."
 
 #: src/rmdStrings.py:33
@@ -137,7 +137,7 @@ msgstr "תיאור"
 #: src/rmdStrings.py:42
 msgid ""
 "Recording is finished.\n"
-"recordMyDesktop has exited with uknown\n"
+"recordMyDesktop has exited with unknown\n"
 "error code"
 msgstr ""
 "ההקלטה הסתיימה.\n"
@@ -193,7 +193,7 @@ msgstr "לחץ כדי לצאת מהתוכנה"
 #: src/rmdStrings.py:52
 msgid ""
 "Select the video quality of your recording.\n"
-"(Lower quality will require more proccessing power,\n"
+"(Lower quality will require more processing power,\n"
 "so it's recommended, when encoding on the fly,\n"
 "to leave at 100)"
 msgstr ""
@@ -242,7 +242,7 @@ msgid ""
 "Please wait while your recording is being encoded\n"
 "WARNING!!!\n"
 "If you press Cancel or close this window,\n"
-"this proccess cannot be resumed!"
+"this process cannot be resumed!"
 msgstr ""
 "אנא המתן בזמן שהקלטתך מקודד\n"
 "אזהרה!!!\n"
@@ -254,7 +254,7 @@ msgid "complete"
 msgstr "הושלם"
 
 #: src/rmdStrings.py:68
-msgid "Overwite Existing Files"
+msgid "Overwrite Existing Files"
 msgstr "דרוס קבצים קיימים"
 
 #: src/rmdStrings.py:68

--- a/qt-recordmydesktop/po/it.po
+++ b/qt-recordmydesktop/po/it.po
@@ -100,11 +100,11 @@ msgid "Improper window specification."
 msgstr "Descrizione impropria della finestra."
 
 #: src/rmdStrings.py:31
-msgid "Cannot attach shared memory to proccess."
+msgid "Cannot attach shared memory to process."
 msgstr "Impossibile assegnare la memoria condivisa ai processi."
 
 #: src/rmdStrings.py:32
-msgid "Cannot open file for writting."
+msgid "Cannot open file for writing."
 msgstr "Impossibile aprire il file per la scrittura."
 
 #: src/rmdStrings.py:33
@@ -142,7 +142,7 @@ msgstr "Descrizione"
 #: src/rmdStrings.py:42
 msgid ""
 "Recording is finished.\n"
-"recordMyDesktop has exited with uknown\n"
+"recordMyDesktop has exited with unknown\n"
 "error code"
 msgstr ""
 "La registrazione è terminata.\n"
@@ -198,7 +198,7 @@ msgstr "Premere qui, per uscire dal programma."
 #: src/rmdStrings.py:52
 msgid ""
 "Select the video quality of your recording.\n"
-"(Lower quality will require more proccessing power,\n"
+"(Lower quality will require more processing power,\n"
 "so it's recommended, when encoding on the fly,\n"
 "to leave at 100)"
 msgstr ""
@@ -249,7 +249,7 @@ msgid ""
 "Please wait while your recording is being encoded\n"
 "WARNING!!!\n"
 "If you press Cancel or close this window,\n"
-"this proccess cannot be resumed!"
+"this process cannot be resumed!"
 msgstr ""
 "Attendere fin quando la registrazione sarà terminata\n"
 "ATTENZIONE!!!\n"
@@ -261,7 +261,7 @@ msgid "complete"
 msgstr "completo"
 
 #: src/rmdStrings.py:68
-msgid "Overwite Existing Files"
+msgid "Overwrite Existing Files"
 msgstr "Sovrascrive i file esistenti"
 
 #: src/rmdStrings.py:68

--- a/qt-recordmydesktop/po/ja.po
+++ b/qt-recordmydesktop/po/ja.po
@@ -92,11 +92,11 @@ msgid "Improper window specification."
 msgstr "不適切ウインドー選択"
 
 #: src/rmdStrings.py:31
-msgid "Cannot attach shared memory to proccess."
+msgid "Cannot attach shared memory to process."
 msgstr "プルセスにシェアードメモリ繋がれなかった"
 
 #: src/rmdStrings.py:32
-msgid "Cannot open file for writting."
+msgid "Cannot open file for writing."
 msgstr "ファイル書き込みする為に開けなかった"
 
 #: src/rmdStrings.py:33
@@ -134,7 +134,7 @@ msgstr "詳細"
 #: src/rmdStrings.py:42
 msgid ""
 "Recording is finished.\n"
-"recordMyDesktop has exited with uknown\n"
+"recordMyDesktop has exited with unknown\n"
 "error code"
 msgstr ""
 "登録完了\n"
@@ -185,7 +185,7 @@ msgstr "クリックして終了"
 #: src/rmdStrings.py:52
 msgid ""
 "Select the video quality of your recording.\n"
-"(Lower quality will require more proccessing power,\n"
+"(Lower quality will require more processing power,\n"
 "so it's recommended, when encoding on the fly,\n"
 "to leave at 100)"
 msgstr ""
@@ -234,7 +234,7 @@ msgid ""
 "Please wait while your recording is being encoded\n"
 "WARNING!!!\n"
 "If you press Cancel or close this window,\n"
-"this proccess cannot be resumed!"
+"this process cannot be resumed!"
 msgstr ""
 "エンコードしている間、お待ちください。\n"
 "ご注意！\n"
@@ -245,7 +245,7 @@ msgid "complete"
 msgstr "完了"
 
 #: src/rmdStrings.py:68
-msgid "Overwite Existing Files"
+msgid "Overwrite Existing Files"
 msgstr "ファイルを上書きする"
 
 #: src/rmdStrings.py:68

--- a/qt-recordmydesktop/po/messages.pot
+++ b/qt-recordmydesktop/po/messages.pot
@@ -92,11 +92,11 @@ msgid "Improper window specification."
 msgstr ""
 
 #: src/rmdStrings.py:31
-msgid "Cannot attach shared memory to proccess."
+msgid "Cannot attach shared memory to process."
 msgstr ""
 
 #: src/rmdStrings.py:32
-msgid "Cannot open file for writting."
+msgid "Cannot open file for writing."
 msgstr ""
 
 #: src/rmdStrings.py:33
@@ -132,7 +132,7 @@ msgstr ""
 #: src/rmdStrings.py:42
 msgid ""
 "Recording is finished.\n"
-"recordMyDesktop has exited with uknown\n"
+"recordMyDesktop has exited with unknown\n"
 "error code"
 msgstr ""
 
@@ -178,7 +178,7 @@ msgstr ""
 #: src/rmdStrings.py:52
 msgid ""
 "Select the video quality of your recording.\n"
-"(Lower quality will require more proccessing power,\n"
+"(Lower quality will require more processing power,\n"
 "so it's recommended, when encoding on the fly,\n"
 "to leave at 100)"
 msgstr ""
@@ -220,7 +220,7 @@ msgid ""
 "Please wait while your recording is being encoded\n"
 "WARNING!!!\n"
 "If you press Cancel or close this window,\n"
-"this proccess cannot be resumed!"
+"this process cannot be resumed!"
 msgstr ""
 
 #: src/rmdStrings.py:65
@@ -228,7 +228,7 @@ msgid "complete"
 msgstr ""
 
 #: src/rmdStrings.py:68
-msgid "Overwite Existing Files"
+msgid "Overwrite Existing Files"
 msgstr ""
 
 #: src/rmdStrings.py:68

--- a/qt-recordmydesktop/po/nl.po
+++ b/qt-recordmydesktop/po/nl.po
@@ -95,11 +95,11 @@ msgid "Improper window specification."
 msgstr "Verkeerde vensterspecificatie"
 
 #: src/rmdStrings.py:31
-msgid "Cannot attach shared memory to proccess."
+msgid "Cannot attach shared memory to process."
 msgstr "Kan gedeeld geheugen niet verbinden aan proces"
 
 #: src/rmdStrings.py:32
-msgid "Cannot open file for writting."
+msgid "Cannot open file for writing."
 msgstr "Kan bestand niet openen voor schrijven"
 
 #: src/rmdStrings.py:33
@@ -137,7 +137,7 @@ msgstr "Beschrijving"
 #: src/rmdStrings.py:42
 msgid ""
 "Recording is finished.\n"
-"recordMyDesktop has exited with uknown\n"
+"recordMyDesktop has exited with unknown\n"
 "error code"
 msgstr ""
 "Opname is beeindigd. "
@@ -193,7 +193,7 @@ msgstr "Klik om het programma te beeindigen"
 #: src/rmdStrings.py:52
 msgid ""
 "Select the video quality of your recording.\n"
-"(Lower quality will require more proccessing power,\n"
+"(Lower quality will require more processing power,\n"
 "so it's recommended, when encoding on the fly,\n"
 "to leave at 100)"
 msgstr ""
@@ -243,7 +243,7 @@ msgid ""
 "Please wait while your recording is being encoded\n"
 "WARNING!!!\n"
 "If you press Cancel or close this window,\n"
-"this proccess cannot be resumed!"
+"this process cannot be resumed!"
 msgstr ""
 "Wacht aub terwijl de opname word gecodeerd\n"
 "WAARSCHUWING!!!\n"
@@ -255,7 +255,7 @@ msgid "complete"
 msgstr "Compleet"
 
 #: src/rmdStrings.py:68
-msgid "Overwite Existing Files"
+msgid "Overwrite Existing Files"
 msgstr "Overschrijf bestaande bestanden"
 
 #: src/rmdStrings.py:68

--- a/qt-recordmydesktop/po/pl.po
+++ b/qt-recordmydesktop/po/pl.po
@@ -98,11 +98,11 @@ msgid "Improper window specification."
 msgstr "Niepoprawne określenie okna."
 
 #: src/rmdStrings.py:31
-msgid "Cannot attach shared memory to proccess."
+msgid "Cannot attach shared memory to process."
 msgstr "Nie można dołączyć pamięci dzielonej do procesu."
 
 #: src/rmdStrings.py:32
-msgid "Cannot open file for writting."
+msgid "Cannot open file for writing."
 msgstr "Nie można otworzyć pliku do zapisu."
 
 #: src/rmdStrings.py:33
@@ -140,7 +140,7 @@ msgstr "Opis"
 #: src/rmdStrings.py:42
 msgid ""
 "Recording is finished.\n"
-"recordMyDesktop has exited with uknown\n"
+"recordMyDesktop has exited with unknown\n"
 "error code"
 msgstr ""
 "Nagrywanie zakończone.\n"
@@ -196,7 +196,7 @@ msgstr "Kliknij aby zakończyć program."
 #: src/rmdStrings.py:52
 msgid ""
 "Select the video quality of your recording.\n"
-"(Lower quality will require more proccessing power,\n"
+"(Lower quality will require more processing power,\n"
 "so it's recommended, when encoding on the fly,\n"
 "to leave at 100)"
 msgstr ""
@@ -246,7 +246,7 @@ msgid ""
 "Please wait while your recording is being encoded\n"
 "WARNING!!!\n"
 "If you press Cancel or close this window,\n"
-"this proccess cannot be resumed!"
+"this process cannot be resumed!"
 msgstr ""
 "Proszę czekać. Trwa kodowanie nagrania\n"
 "UWAGA!!!\n"
@@ -258,7 +258,7 @@ msgid "complete"
 msgstr "ukończone"
 
 #: src/rmdStrings.py:68
-msgid "Overwite Existing Files"
+msgid "Overwrite Existing Files"
 msgstr "Nadpisuj istniejące pliki"
 
 #: src/rmdStrings.py:68

--- a/qt-recordmydesktop/po/pt.po
+++ b/qt-recordmydesktop/po/pt.po
@@ -90,11 +90,11 @@ msgid "Improper window specification."
 msgstr "Janela improriada especificada"
 
 #: src/rmdStrings.py:31
-msgid "Cannot attach shared memory to proccess."
+msgid "Cannot attach shared memory to process."
 msgstr "Impossivel anexar memória partilhada ao processo"
 
 #: src/rmdStrings.py:32
-msgid "Cannot open file for writting."
+msgid "Cannot open file for writing."
 msgstr "Impossivel abrir o ficheiro para escrever"
 
 #: src/rmdStrings.py:33
@@ -132,7 +132,7 @@ msgstr "Descrição"
 #: src/rmdStrings.py:42
 msgid ""
 "Recording is finished.\n"
-"recordMyDesktop has exited with uknown\n"
+"recordMyDesktop has exited with unknown\n"
 "error code"
 msgstr ""
 "Gravação terminada.\n"
@@ -188,7 +188,7 @@ msgstr "Clique aqui para sair do programa"
 #: src/rmdStrings.py:52
 msgid ""
 "Select the video quality of your recording.\n"
-"(Lower quality will require more proccessing power,\n"
+"(Lower quality will require more processing power,\n"
 "so it's recommended, when encoding on the fly,\n"
 "to leave at 100)"
 msgstr ""
@@ -239,7 +239,7 @@ msgid ""
 "Please wait while your recording is being encoded\n"
 "WARNING!!!\n"
 "If you press Cancel or close this window,\n"
-"this proccess cannot be resumed!"
+"this process cannot be resumed!"
 msgstr ""
 "Por favor espere enquanto a sua gravação é codificada\n"
 "AVISO!!\n"
@@ -251,7 +251,7 @@ msgid "complete"
 msgstr "completo"
 
 #: src/rmdStrings.py:68
-msgid "Overwite Existing Files"
+msgid "Overwrite Existing Files"
 msgstr "Sobrepor Ficheiros Existentes"
 
 #: src/rmdStrings.py:68

--- a/qt-recordmydesktop/po/pt_BR.po
+++ b/qt-recordmydesktop/po/pt_BR.po
@@ -92,11 +92,11 @@ msgid "Improper window specification."
 msgstr "Janela imprópria especificada."
 
 #: src/rmdStrings.py:31
-msgid "Cannot attach shared memory to proccess."
+msgid "Cannot attach shared memory to process."
 msgstr "Impossível anexar memória partilhada ao processo"
 
 #: src/rmdStrings.py:32
-msgid "Cannot open file for writting."
+msgid "Cannot open file for writing."
 msgstr "Impossível abrir o arquivo para escrever"
 
 #: src/rmdStrings.py:33
@@ -135,7 +135,7 @@ msgstr "Descrição"
 #: src/rmdStrings.py:42
 msgid ""
 "Recording is finished.\n"
-"recordMyDesktop has exited with uknown\n"
+"recordMyDesktop has exited with unknown\n"
 "error code"
 msgstr ""
 "Gravação terminada.\n"
@@ -191,7 +191,7 @@ msgstr "Clique aqui para sair do programa."
 #: src/rmdStrings.py:52
 msgid ""
 "Select the video quality of your recording.\n"
-"(Lower quality will require more proccessing power,\n"
+"(Lower quality will require more processing power,\n"
 "so it's recommended, when encoding on the fly,\n"
 "to leave at 100)"
 msgstr ""
@@ -242,7 +242,7 @@ msgid ""
 "Please wait while your recording is being encoded\n"
 "WARNING!!!\n"
 "If you press Cancel or close this window,\n"
-"this proccess cannot be resumed!"
+"this process cannot be resumed!"
 msgstr ""
 "Por favor espere enquanto a sua gravação é codificada\n"
 "AVISO!!\n"
@@ -254,7 +254,7 @@ msgid "complete"
 msgstr "completo"
 
 #: src/rmdStrings.py:68
-msgid "Overwite Existing Files"
+msgid "Overwrite Existing Files"
 msgstr "Sobreescrever Arquivos Existentes"
 
 #: src/rmdStrings.py:68

--- a/qt-recordmydesktop/po/ru.po
+++ b/qt-recordmydesktop/po/ru.po
@@ -95,11 +95,11 @@ msgid "Improper window specification."
 msgstr "Неправильные параметры окна"
 
 #: src/rmdStrings.py:31
-msgid "Cannot attach shared memory to proccess."
+msgid "Cannot attach shared memory to process."
 msgstr "Невозможно подключить shared memory к процессу"
 
 #: src/rmdStrings.py:32
-msgid "Cannot open file for writting."
+msgid "Cannot open file for writing."
 msgstr "Невозможно открыть файл на запись"
 
 #: src/rmdStrings.py:33
@@ -138,7 +138,7 @@ msgstr "Описание"
 #: src/rmdStrings.py:42
 msgid ""
 "Recording is finished.\n"
-"recordMyDesktop has exited with uknown\n"
+"recordMyDesktop has exited with unknown\n"
 "error code"
 msgstr ""
 "Запись окончена.\n"
@@ -194,7 +194,7 @@ msgstr "Нажмите для выхода из программы"
 #: src/rmdStrings.py:52
 msgid ""
 "Select the video quality of your recording.\n"
-"(Lower quality will require more proccessing power,\n"
+"(Lower quality will require more processing power,\n"
 "so it's recommended, when encoding on the fly,\n"
 "to leave at 100)"
 msgstr ""
@@ -244,7 +244,7 @@ msgid ""
 "Please wait while your recording is being encoded\n"
 "WARNING!!!\n"
 "If you press Cancel or close this window,\n"
-"this proccess cannot be resumed!"
+"this process cannot be resumed!"
 msgstr ""
 "Пожалуйста, подождите пока ваша запись кодируется\n"
 "ВНИМАНИЕ!!!\n"
@@ -256,7 +256,7 @@ msgid "complete"
 msgstr "готово"
 
 #: src/rmdStrings.py:68
-msgid "Overwite Existing Files"
+msgid "Overwrite Existing Files"
 msgstr "Переписать существующие файлы"
 
 #: src/rmdStrings.py:68

--- a/qt-recordmydesktop/po/sv.po
+++ b/qt-recordmydesktop/po/sv.po
@@ -95,11 +95,11 @@ msgid "Improper window specification."
 msgstr "Felaktig fönsterspecifikation."
 
 #: ../src/rmdStrings.py:31
-msgid "Cannot attach shared memory to proccess."
+msgid "Cannot attach shared memory to process."
 msgstr "Kan inte fästa delat minne till process."
 
 #: ../src/rmdStrings.py:32
-msgid "Cannot open file for writting."
+msgid "Cannot open file for writing."
 msgstr "Kan inte öppna fil för skrivning."
 
 #: ../src/rmdStrings.py:33
@@ -137,7 +137,7 @@ msgstr "Beskrivning"
 #: ../src/rmdStrings.py:42
 msgid ""
 "Recording is finished.\n"
-"recordMyDesktop has exited with uknown\n"
+"recordMyDesktop has exited with unknown\n"
 "error code"
 msgstr ""
 "Inspelningen är färdig.\n"
@@ -195,7 +195,7 @@ msgstr "Klicka för att avsluta programmet."
 #: ../src/rmdStrings.py:52
 msgid ""
 "Select the video quality of your recording.\n"
-"(Lower quality will require more proccessing power,\n"
+"(Lower quality will require more processing power,\n"
 "so it's recommended, when encoding on the fly,\n"
 "to leave at 100)"
 msgstr ""
@@ -245,7 +245,7 @@ msgid ""
 "Please wait while your recording is being encoded\n"
 "WARNING!!!\n"
 "If you press Cancel or close this window,\n"
-"this proccess cannot be resumed!"
+"this process cannot be resumed!"
 msgstr ""
 "Vänta under tiden din inspelning kodas\n"
 "VARNING!!!\n"
@@ -257,7 +257,7 @@ msgid "complete"
 msgstr "färdig"
 
 #: ../src/rmdStrings.py:68
-msgid "Overwite Existing Files"
+msgid "Overwrite Existing Files"
 msgstr "Skriv över befintliga filer"
 
 #: ../src/rmdStrings.py:68

--- a/qt-recordmydesktop/po/tr.po
+++ b/qt-recordmydesktop/po/tr.po
@@ -99,11 +99,11 @@ msgid "Improper window specification."
 msgstr "Yanlış pencere seçimi."
 
 #: src/rmdStrings.py:31
-msgid "Cannot attach shared memory to proccess."
+msgid "Cannot attach shared memory to process."
 msgstr "Ortak bellek sürece eklenemedi."
 
 #: src/rmdStrings.py:32
-msgid "Cannot open file for writting."
+msgid "Cannot open file for writing."
 msgstr "Dosyayı yazmak için açamadı."
 
 #: src/rmdStrings.py:33
@@ -141,7 +141,7 @@ msgstr "Açıklama"
 #: src/rmdStrings.py:42
 msgid ""
 "Recording is finished.\n"
-"recordMyDesktop has exited with uknown\n"
+"recordMyDesktop has exited with unknown\n"
 "error code"
 msgstr ""
 "Kayıt işlemi tamamlandı.\n"
@@ -197,7 +197,7 @@ msgstr "Programdan çıkmak için tıklayın."
 #: src/rmdStrings.py:52
 msgid ""
 "Select the video quality of your recording.\n"
-"(Lower quality will require more proccessing power,\n"
+"(Lower quality will require more processing power,\n"
 "so it's recommended, when encoding on the fly,\n"
 "to leave at 100)"
 msgstr ""
@@ -247,7 +247,7 @@ msgid ""
 "Please wait while your recording is being encoded\n"
 "WARNING!!!\n"
 "If you press Cancel or close this window,\n"
-"this proccess cannot be resumed!"
+"this process cannot be resumed!"
 msgstr ""
 "Lütfen kayıt kodlanırken bekleyin\n"
 "UYARI!!!\n"
@@ -259,7 +259,7 @@ msgid "complete"
 msgstr "tamamlandı"
 
 #: src/rmdStrings.py:68
-msgid "Overwite Existing Files"
+msgid "Overwrite Existing Files"
 msgstr "Varolan Dosyaların Üstüne Yaz"
 
 #: src/rmdStrings.py:68

--- a/qt-recordmydesktop/po/zh_CN.po
+++ b/qt-recordmydesktop/po/zh_CN.po
@@ -95,11 +95,11 @@ msgid "Improper window specification."
 msgstr "窗口规格不合法。"
 
 #: src/rmdStrings.py:31
-msgid "Cannot attach shared memory to proccess."
+msgid "Cannot attach shared memory to process."
 msgstr "无法向进程附加共享内存。"
 
 #: src/rmdStrings.py:32
-msgid "Cannot open file for writting."
+msgid "Cannot open file for writing."
 msgstr "无法打开文件以写入。"
 
 #: src/rmdStrings.py:33
@@ -137,7 +137,7 @@ msgstr "描述"
 #: src/rmdStrings.py:42
 msgid ""
 "Recording is finished.\n"
-"recordMyDesktop has exited with uknown\n"
+"recordMyDesktop has exited with unknown\n"
 "error code"
 msgstr ""
 "记录结束。\n"
@@ -191,7 +191,7 @@ msgstr "点击以退出程序。"
 #: src/rmdStrings.py:52
 msgid ""
 "Select the video quality of your recording.\n"
-"(Lower quality will require more proccessing power,\n"
+"(Lower quality will require more processing power,\n"
 "so it's recommended, when encoding on the fly,\n"
 "to leave at 100)"
 msgstr ""
@@ -238,7 +238,7 @@ msgid ""
 "Please wait while your recording is being encoded\n"
 "WARNING!!!\n"
 "If you press Cancel or close this window,\n"
-"this proccess cannot be resumed!"
+"this process cannot be resumed!"
 msgstr ""
 "当记录进行时请稍等\n"
 "警告！！！\n"
@@ -249,7 +249,7 @@ msgid "complete"
 msgstr "完成"
 
 #: src/rmdStrings.py:68
-msgid "Overwite Existing Files"
+msgid "Overwrite Existing Files"
 msgstr "覆盖已存在文件"
 
 #: src/rmdStrings.py:68

--- a/qt-recordmydesktop/src/qt-recordMyDesktop.in
+++ b/qt-recordmydesktop/src/qt-recordMyDesktop.in
@@ -26,7 +26,7 @@
 from PyQt4 import QtGui,QtCore
 import sys
 
-#this is the installation direcotry,
+#this is the installation directory,
 #which is determined during configuration
 #default /usr/local/lib/python<version>/site-packages
 PYTHONDIR='@PYTHONDIR@'

--- a/qt-recordmydesktop/src/rmdSimple.py
+++ b/qt-recordmydesktop/src/rmdSimple.py
@@ -285,7 +285,7 @@ class simpleWidget(object):
             #the header
             savefile.readline()
             savefile.readline()
-            #the options,each has a coment above
+            #the options,each has a comment above
             for i in range(2):
                 savefile.readline()
                 self.values.append(int(savefile.readline()))

--- a/qt-recordmydesktop/src/rmdStrings.py
+++ b/qt-recordmydesktop/src/rmdStrings.py
@@ -52,8 +52,8 @@ rmdErrStr={
         9*256:_('Cannot connect to Xserver.'),
         10*256:_('Color depth is not 24bpp.'),
         11*256:_('Improper window specification.'),
-        12*256:_('Cannot attach shared memory to proccess.'),
-        13*256:_('Cannot open file for writting.'),
+        12*256:_('Cannot attach shared memory to process.'),
+        13*256:_('Cannot open file for writing.'),
         14*256:_('Cannot load the Jack library (dlopen/dlsym error on libjack.so).'),
         15*256:_('Cannot create new client.'),
         16*256:_('Cannot activate client.'),
@@ -63,7 +63,7 @@ rmdErrStr={
 TrayIconStr={
         'RecFinishedKnown':_("Recording is finished.\nrecordMyDesktop has exited with status"),
         'ErrDesc':_("Description"),
-        'RecFinishedUnknown':_("Recording is finished.\nrecordMyDesktop has exited with uknown\nerror code")
+        'RecFinishedUnknown':_("Recording is finished.\nrecordMyDesktop has exited with unknown\nerror code")
    }
 
 
@@ -73,7 +73,7 @@ smplTooltipLabels=[_('Click here to select a window to record'),
                 _('Click to start the recording.\nThis window will hide itself.'),
                 _('Click to choose a filename and location.\nDefault is out.ogv in your home folder.\nIf the file already exists, the new one\nwill have a number attached on its name\n(this behavior can be changed )'),
                 _('Click to exit the program.'),
-                _('Select the video quality of your recording.\n(Lower quality will require more proccessing power,\nso it\'s recommended, when encoding on the fly,\nto leave at 100)'),
+                _('Select the video quality of your recording.\n(Lower quality will require more processing power,\nso it\'s recommended, when encoding on the fly,\nto leave at 100)'),
                 _('Enable/Disable sound recording.'),
                 _('Select the audio quality of your recording.'),
                 _('Click here to access more options.')]
@@ -85,11 +85,11 @@ smplStrings={   'Record':_("Record"),
     }
 
 monStrings={'Cancel':_("Cancel"),
-            'PleaseWait':_("Please wait while your recording is being encoded\nWARNING!!!\nIf you press Cancel or close this window,\nthis proccess cannot be resumed!"),
+            'PleaseWait':_("Please wait while your recording is being encoded\nWARNING!!!\nIf you press Cancel or close this window,\nthis process cannot be resumed!"),
             'complete':_("complete")
     }
 
-prefLabelStrings=[_('Overwite Existing Files'),_('Working Directory'),
+prefLabelStrings=[_('Overwrite Existing Files'),_('Working Directory'),
                 _('Frames Per Second'),_('Encode On the Fly'),_('Zero Compression'),
                 _('Quick Subsampling'),_('Full shots at every frame'),
                 _('Channels'),_('Frequency'),_('Device'),_('Display'),_('Mouse Cursor'),

--- a/recordmydesktop/INSTALL
+++ b/recordmydesktop/INSTALL
@@ -1,6 +1,6 @@
-If you got this from cvs you need to have automake installed and run:
+If you got this from git you need to have automake installed and run:
 
-~$ cd recordmydesktop           #remeber to cd in the directory of the module
+~$ cd recordmydesktop           #remember to cd in the directory of the module
                                 #you checked out
 ~$ sh autogen.sh
 ~$ ./configure

--- a/recordmydesktop/README
+++ b/recordmydesktop/README
@@ -23,7 +23,7 @@
 *                                                                             *
 ******************************************************************************/
 
-Complete lisence can be found in the COPYING file.
+Complete licence can be found in the COPYING file.
 Installation and compilation instruction can be found in the INSTALL file.
 
 REMEMBER TO READ THE MANPAGE BEFORE RUNNING THE PROGRAM.

--- a/recordmydesktop/src/rmd.c
+++ b/recordmydesktop/src/rmd.c
@@ -164,7 +164,7 @@ int main(int argc,char **argv){
                 }
                 fprintf(stderr,"Cleaning up cache...\n");
                 if(rmdPurgeCache(pdata.cache_data,!pdata.args.nosound))
-                    fprintf(stderr,"Some error occured "
+                    fprintf(stderr,"Some error occurred "
                                 "while cleaning up cache!\n");
                 fprintf(stderr,"Done!!!\n");
             }

--- a/recordmydesktop/src/rmd_cache.h
+++ b/recordmydesktop/src/rmd_cache.h
@@ -35,7 +35,7 @@
 
 
 /**
-* Change file pointer to a new file while writting
+* Change file pointer to a new file while writing
 * (file name is incremented with CacheFileN)
 *
 * \param name base file name

--- a/recordmydesktop/src/rmd_cache_frame.c
+++ b/recordmydesktop/src/rmd_cache_frame.c
@@ -257,7 +257,7 @@ void *rmdCacheImageBuffer(ProgData *pdata){
                                 //clean exit.
                                 //In either case data will be preserved so if
                                 //space is freed the recording
-                                //can be proccessed later.
+                                //can be processed later.
             }
             total_bytes += nbytes;
             nth_cache++;

--- a/recordmydesktop/src/rmd_capture_sound.c
+++ b/recordmydesktop/src/rmd_capture_sound.c
@@ -121,7 +121,7 @@ void *rmdCaptureSound(ProgData *pdata){
                 snd_pcm_prepare(pdata->sound_handle);
             }
             else if (temp_sret<0){
-                fprintf(stderr,"An error occured while reading sound data:\n"
+                fprintf(stderr,"An error occurred while reading sound data:\n"
                                " %s\n",
                                snd_strerror(temp_sret));
                 snd_pcm_prepare(pdata->sound_handle);
@@ -138,7 +138,7 @@ void *rmdCaptureSound(ProgData *pdata){
                                ((pdata->args.buffsize<<1)*
                                 pdata->args.channels)-sret);
             if(temp_sret<0){
-                fprintf(stderr,"An error occured while reading from soundcard"
+                fprintf(stderr,"An error occurred while reading from soundcard"
                                "%s\n"
                                "Error description:\n"
                                "%s\n",pdata->args.device,strerror(errno));
@@ -161,7 +161,7 @@ void *rmdCaptureSound(ProgData *pdata){
         pthread_mutex_unlock(&pdata->sound_buffer_mutex);
 
 
-        //signal that there are data to be proccessed
+        //signal that there are data to be processed
         pthread_mutex_lock(&pdata->snd_buff_ready_mutex);
         pthread_cond_signal(&pdata->sound_data_read);
         pthread_mutex_unlock(&pdata->snd_buff_ready_mutex);

--- a/recordmydesktop/src/rmd_frame.h
+++ b/recordmydesktop/src/rmd_frame.h
@@ -83,7 +83,7 @@ void rmdMoveFrame(Display *dpy,
  *
  * \param screen Recorded screen
  *
- * \param win WindoID of the frame
+ * \param win WindowID of the frame
  *
  * \param width Width of the recorded area
  *

--- a/recordmydesktop/src/rmd_get_frame.c
+++ b/recordmydesktop/src/rmd_get_frame.c
@@ -243,7 +243,7 @@ static int rmdFirstFrame(ProgData *pdata,
                                                         NULL,0);
         (*shminfo).readOnly = False;
         if(!XShmAttach(pdata->dpy,shminfo)){
-            fprintf(stderr,"Failed to attach shared memory to proccess.\n");
+            fprintf(stderr,"Failed to attach shared memory to process.\n");
             return 12;
         }
         XShmGetImage(pdata->dpy,

--- a/recordmydesktop/src/rmd_init_encoder.c
+++ b/recordmydesktop/src/rmd_init_encoder.c
@@ -126,7 +126,7 @@ void rmdInitEncoder(ProgData *pdata,EncData *enc_data_t,int buffer_ready){
         
     enc_data_t->fp=fopen((pdata)->args.filename,"w");
     if(enc_data_t->fp==NULL){
-        fprintf(stderr,"Cannot open file %s for writting!\n",
+        fprintf(stderr,"Cannot open file %s for writing!\n",
                        (pdata)->args.filename);
         exit(13);
     }

--- a/recordmydesktop/src/rmd_init_encoder.h
+++ b/recordmydesktop/src/rmd_init_encoder.h
@@ -37,7 +37,7 @@
 * \param enc_data_t Encoding options
 *
 * \param buffer_ready when 1, the yuv buffer must be preallocated
-*                     when 0 rmdInitEncoder will alocate a new one
+*                     when 0 rmdInitEncoder will allocate a new one
 *
 */
 void rmdInitEncoder(ProgData *pdata,EncData *enc_data_t,int buffer_ready);

--- a/recordmydesktop/src/rmd_jack.c
+++ b/recordmydesktop/src/rmd_jack.c
@@ -66,7 +66,7 @@ static int rmdJackCapture(jack_nframes_t nframes,void *jdata_t) {
 /*FIXME */
 //This is not safe.
 //cond_var signaling must move away from signal handlers
-//alltogether (rmdJackCapture, SetExpired, SetPaused).
+//altogether (rmdJackCapture, SetExpired, SetPaused).
 //Better would be a set of pipes for each of these.
 //The callback should write on the pipe and the main thread
 //should perform a select over the fd's, signaling afterwards the

--- a/recordmydesktop/src/rmd_jack.h
+++ b/recordmydesktop/src/rmd_jack.h
@@ -38,7 +38,7 @@
 *                   and client information
 *
 *   \returns 0 on Success, error code on failure
-*            (depending on where the error occured)
+*            (depending on where the error occurred)
 */
 int rmdStartJackClient(JackData *jdata);
 

--- a/recordmydesktop/src/rmd_load_cache.c
+++ b/recordmydesktop/src/rmd_load_cache.c
@@ -164,7 +164,7 @@ void *rmdLoadCache(ProgData *pdata){
         audio_end=0,
         extra_frames=0,//total number of duplicated frames
         missing_frames=0,//if this is found >0 current run will not load
-                        //a frame but it will proccess the previous
+                        //a frame but it will process the previous
         thread_exit=0,//0 success, -1 couldn't find files,1 couldn't remove
         blocknum_x=pdata->enc_data->yuv.y_width/Y_UNIT_WIDTH,
         blocknum_y=pdata->enc_data->yuv.y_height/Y_UNIT_WIDTH,
@@ -211,7 +211,7 @@ void *rmdLoadCache(ProgData *pdata){
         }
     }
 
-    //this will be used now to define if we proccess audio or video
+    //this will be used now to define if we process audio or video
     //on any given loop.
     pdata->avd=0;
     //If sound finishes first,we go on with the video.

--- a/recordmydesktop/src/rmd_parseargs.c
+++ b/recordmydesktop/src/rmd_parseargs.c
@@ -143,7 +143,7 @@ boolean rmdParseArgs(int argc, char **argv, ProgArgs *arg_return) {
 
         { "full-shots", '\0',
           POPT_ARG_NONE, &arg_return->full_shots, 0,
-          "Take full screenshot at every frame(Not recomended!).",
+          "Take full screenshot at every frame(Not recommended!).",
           NULL },
 
         { "follow-mouse", '\0',

--- a/recordmydesktop/src/rmd_poll_events.h
+++ b/recordmydesktop/src/rmd_poll_events.h
@@ -38,7 +38,7 @@ void rmdInitEventsPolling(ProgData *pdata);
 
 /**
 * Loop calling XNextEvent.Retrieve and place on
-* list damage events that arive, create damage for new windows
+* list damage events that arrive, create damage for new windows
 * and pickup key events for shortcuts.
 * \param pdata ProgData struct containing all program data
 */

--- a/recordmydesktop/src/rmd_rectinsert.c
+++ b/recordmydesktop/src/rmd_rectinsert.c
@@ -320,7 +320,7 @@ int rmdRectInsert(RectArea **root,XRectangle *xrect){
 
         int nrects=0,insert_ok=1,i=0;
         temp=*root;
-        while(insert_ok){   //if something is broken list does not procceed
+        while(insert_ok){   //if something is broken list does not proceed
                             //(except on -1 collres case)
             int collres = rmdCollideRects(&temp->rect, xrect, &xrect_return[0], &nrects);
             if((!collres))

--- a/recordmydesktop/src/rmd_setbrwindow.c
+++ b/recordmydesktop/src/rmd_setbrwindow.c
@@ -47,7 +47,7 @@ static void rmdSizePack2_8_16(short *start, unsigned short *size, unsigned short
     //align in two
     //an odd x can always go down and still be in recording area.
     //Resolutions come in even numbers
-    //so if x is an odd numer, width max is an odd number, too
+    //so if x is an odd number, width max is an odd number, too
     //thus since x will go down one then width can go up one too and still
     //be inbounds
     (*size)+=((*size)%2)|((*start)%2);

--- a/recordmydesktop/src/rmd_setbrwindow.h
+++ b/recordmydesktop/src/rmd_setbrwindow.h
@@ -34,7 +34,7 @@
 *
 * \param dpy Connection to the server
 *
-* \param brwin BRWindow struct contaning the initial and final window
+* \param brwin BRWindow struct containing the initial and final window
 *
 * \param specs DisplaySpecs struct with
 *              information about the display to be recorded

--- a/recordmydesktop/src/rmd_shortcuts.c
+++ b/recordmydesktop/src/rmd_shortcuts.c
@@ -66,7 +66,7 @@ int rmdRegisterShortcut(Display *dpy,
     
     //we register the shortcut on the root
     //window, which means on every keypress event,
-    //so I think it's neccessary to have at least one 
+    //so I think it's necessary to have at least one
     //modifier.
     if(modifier_mask == 0)
         return 1;

--- a/recordmydesktop/src/rmd_shortcuts.h
+++ b/recordmydesktop/src/rmd_shortcuts.h
@@ -37,7 +37,7 @@
  *
  * \param root Root window id
  *
- * \param shortcut String represantation of the shortcut
+ * \param shortcut String representation of the shortcut
  *
  * \param HotKey Pre-allocated struct that is filled with the 
  *               modifiers and the keycode, for checks on incoming 

--- a/recordmydesktop/src/rmd_specsfile.h
+++ b/recordmydesktop/src/rmd_specsfile.h
@@ -43,11 +43,11 @@ int rmdWriteSpecsFile(ProgData *pdata);
 
 
 /*
- * Read the  text file that holds the required
+ * Read the text file that holds the required
  * capture attributes, in the cache directory.
  *
- * \param pdata ProgData struct that will be fille 
- *        with  all program data
+ * \param pdata ProgData struct that will be filled
+ *        with all program data
  *
  * \returns 0 on Success, 1 on failure
  *

--- a/recordmydesktop/src/rmd_types.h
+++ b/recordmydesktop/src/rmd_types.h
@@ -66,7 +66,7 @@ typedef u_int64_t cmp_int_t;
 typedef u_int32_t cmp_int_t;
 #endif
 
-//type of pixel proccessing for the Cb,Cr planes
+//type of pixel processing for the Cb,Cr planes
 //when converting from full rgb to 4:2:2 Ycbcr
 enum{
     __PXL_DISCARD,  //only select 1 pixel in every block of four
@@ -146,7 +146,7 @@ typedef struct _ProgArgs{
     char *stop_shortcut;    //stop shortcut sequence(Control+Alt+s)
     int noframe;            //don't draw a frame around the recording area
     int zerocompression;    //image data are always flushed uncompressed
-    int overwrite;          //overwite a previously existing file
+    int overwrite;          //overwrite a previously existing file
                             //(do not add a .number postfix)
     int use_jack;           //record audio with jack
     unsigned int jack_nports;
@@ -155,7 +155,7 @@ typedef struct _ProgArgs{
 }ProgArgs;
 
 //this struct holds anything related to encoding AND
-//writting out to file.
+//writing out to file.
 typedef struct _EncData{
     ogg_stream_state m_ogg_ts;  //theora
     ogg_stream_state m_ogg_vs;  //vorbis
@@ -191,7 +191,7 @@ typedef struct _CacheData{
             *projname,  //This is the name of the folder that
                         //will hold the project.
                         //It is rMD-session-%d where %d is the pid
-                        //of the current proccess.
+                        //of the current process.
                         //This way, running two instances
                         //will not create problems
                         //and also, a frontend can identify
@@ -225,7 +225,7 @@ typedef struct _JackData{
                     nports;     //number of ports.
     float           ringbuffer_secs;
     char **port_names;          //names of ports(as specified in args).
-    jack_port_t **ports;        //connections to thes ports.
+    jack_port_t **ports;        //connections to the ports.
     jack_default_audio_sample_t **portbuf;  //retrieval of audio buffers.
     pthread_mutex_t *snd_buff_ready_mutex;  //mutex and cond_var
     pthread_cond_t *sound_data_read;        //in the pdata struct
@@ -281,10 +281,10 @@ struct _ProgData {
                                 //whenever it's time to get a screenshot
                     pause_cond, //this is blocks execution,
                                 //when program is paused
-                    sound_data_read,    //a buffer is ready for proccessing
+                    sound_data_read,    //a buffer is ready for processing
                     image_buffer_ready, //image encoding finished
                     theora_lib_clean,   //the flush_ogg thread cannot
-                                        //procceed to creating last
+                                        //proceed to creating last
                     vorbis_lib_clean;   //packages until these two libs
                                         //are no longer used, by other threads
 /**Buffers,Flags and other vars*/
@@ -308,10 +308,10 @@ struct _ProgData {
         timer_alive,        //determines loop of timer thread
         hard_pause,         //if sound device doesn't support pause
                             //we have to close and reopen
-        avd,                //syncronization among audio and video
+        avd,                //synchronization among audio and video
         sound_framesize;    //size of each sound frame
 
-    /** Progam state vars */
+    /** Program state vars */
     boolean running;             //1 while the program is capturing/paused/encoding
     boolean paused;              //1 while the program is paused 
     boolean aborted;             //1 if we should abort

--- a/recordmydesktop/src/rmd_update_image.h
+++ b/recordmydesktop/src/rmd_update_image.h
@@ -42,7 +42,7 @@
 *
 * \param root Root entry of the list with damaged areas
 *
-* \param brwin BRWindow struct contaning the recording window specs
+* \param brwin BRWindow struct containing the recording window specs
 *
 * \param enc Encoding options
 *

--- a/recordmydesktop/src/rmd_wm_is_compositing.c
+++ b/recordmydesktop/src/rmd_wm_is_compositing.c
@@ -44,7 +44,7 @@ boolean rmdWMIsCompositing( Display *dpy, int screen ) {
     
     //If the wm name is queried successfully the wm is compliant (source  
     //http://standards.freedesktop.org/wm-spec/1.4/ar01s03.html#id2568282 )
-    //in which case we will also free() the allcoated string.
+    //in which case we will also free() the allocated string.
     
     if( window_manager == NULL )
         return FALSE;

--- a/recordmydesktop/src/rmd_wm_is_compositing.h
+++ b/recordmydesktop/src/rmd_wm_is_compositing.h
@@ -39,7 +39,7 @@
 * \returns TRUE if compositing, false otherwise or when 
 *          the window manager doesn't support the required
 *          freedesktop.org hints for the test to be done 
-*          succesfully.
+*          successfully.
 */
 
 boolean rmdWMIsCompositing( Display *dpy, int screen) ; 

--- a/recordmydesktop/src/rmd_yuv_utils.c
+++ b/recordmydesktop/src/rmd_yuv_utils.c
@@ -36,7 +36,7 @@ unsigned char Yr[256], Yg[256], Yb[256],
 
 // FIXME: These globals are modified in other source files! We keep
 // thsee here for now. These are the cache blocks. They need to be
-// accesible in the dbuf macros
+// accessible in the dbuf macros
 u_int32_t *yblocks,
           *ublocks,
           *vblocks;

--- a/recordmydesktop/src/rmd_yuv_utils.h
+++ b/recordmydesktop/src/rmd_yuv_utils.h
@@ -51,7 +51,7 @@ extern u_int32_t *yblocks,
 //32 bit arithmetics, so there's no problem.
 //(This note is useless, I'm just adding because
 //the addition of the A components in CALC_TVAL_AVG_32,
-//now removed as uneeded, produced an overflow which would have caused
+//now removed as unneeded, produced an overflow which would have caused
 //color distrtion, where it one of the R,G or B components)
 #define CALC_TVAL_AVG_16(t_val,datapi,datapi_next){\
     register u_int16_t t1,t2,t3,t4;\

--- a/recordmydesktop/src/skeleton.c
+++ b/recordmydesktop/src/skeleton.c
@@ -192,12 +192,12 @@ static int fishead_from_data (const unsigned char * data, int len, fishead_packe
     return 0;
 }
 
-/* fills up a fishead_packet from a fishead ogg_packet of a skeleton bistream */
+/* fills up a fishead_packet from a fishead ogg_packet of a skeleton bitstream */
 int fishead_from_ogg (ogg_packet *op, fishead_packet *fp) {
     return fishead_from_data (op->packet, op->bytes, fp);
 }
 
-/* fills up a fishead_packet from a fishead ogg_page of a skeleton bistream */
+/* fills up a fishead_packet from a fishead ogg_page of a skeleton bitstream */
 int fishead_from_ogg_page (const ogg_page *og, fishead_packet *fp) {
     return fishead_from_data (og->body, og->body_len, fp);
 }
@@ -230,7 +230,7 @@ int fisbone_from_ogg (ogg_packet *op, fisbone_packet *fp) {
   return fisbone_from_data (op->packet, op->bytes, fp);
 }
 
-/* fills up a fisbone_packet from a fisbone ogg_page of a skeleton bistream */
+/* fills up a fisbone_packet from a fisbone ogg_page of a skeleton bitstream */
 int fisbone_from_ogg_page (const ogg_page *og, fisbone_packet *fp) {
     return fisbone_from_data (og->body, og->body_len, fp);
 }


### PR DESCRIPTION
Ran the codebase through [crate-ci/typos](https://github.com/crate-ci/typos) and fixed numerous misspellings (in both code comments and `fprintf()`s and so forth).  There were typos in the Changelogs that I left as-is, but can create another PR for those if wanted.
